### PR TITLE
fix: 홈 기록 리스트 스와이프 상태 단일화 및 초기화

### DIFF
--- a/frontend/OnVoice/Application/ContentView.swift
+++ b/frontend/OnVoice/Application/ContentView.swift
@@ -4,7 +4,7 @@
 //
 import SwiftUI
 
-enum OnVoiceTab {
+enum OnVoiceTab: Equatable {
     case home
     case library
 }

--- a/frontend/OnVoice/View/Components/RecordingRowView.swift
+++ b/frontend/OnVoice/View/Components/RecordingRowView.swift
@@ -22,12 +22,14 @@ enum RecordingRowSwipeBehavior {
         min(0, max(-revealWidth, baseOffset + translation))
     }
 
-    static func targetOpenedRowID(
-        for currentOffset: CGFloat,
+    static func resolvedOpenedRowID(
+        for finalOffset: CGFloat,
         rowID: Recording.ID,
         revealWidth: CGFloat
     ) -> Recording.ID? {
-        currentOffset < -revealWidth / 2 ? rowID : nil
+        // `finalOffset` already reflects the row's baseline state plus the completed drag.
+        // Past halfway, we snap open this row; otherwise we resolve to the fully closed state.
+        finalOffset < -revealWidth / 2 ? rowID : nil
     }
 }
 
@@ -159,7 +161,7 @@ struct RecordingRowView: View {
                     translation: value.translation.width,
                     revealWidth: revealWidth
                 )
-                let targetRowID = RecordingRowSwipeBehavior.targetOpenedRowID(
+                let targetRowID = RecordingRowSwipeBehavior.resolvedOpenedRowID(
                     for: finalOffset,
                     rowID: id,
                     revealWidth: revealWidth

--- a/frontend/OnVoice/View/Components/RecordingRowView.swift
+++ b/frontend/OnVoice/View/Components/RecordingRowView.swift
@@ -6,12 +6,14 @@
 import SwiftUI
 
 struct RecordingRowView: View {
+    let id: Recording.ID
     let title: String
     let subtitle: String
+    @Binding var openedRowID: Recording.ID?
     let onTap: () -> Void
 
-    @State private var offset: CGFloat = 0
-    @State private var dragOffset: CGFloat = 0
+    @State private var restingOffset: CGFloat = 0
+    @GestureState private var dragTranslation: CGFloat = 0
 
     private let revealWidth: CGFloat = 148
 
@@ -22,10 +24,18 @@ struct RecordingRowView: View {
             cardContent
                 .offset(x: currentOffset)
                 .gesture(dragGesture)
+                .onAppear {
+                    restingOffset = targetOffset(for: openedRowID)
+                }
+                .onChange(of: openedRowID) { newValue in
+                    withAnimation(.spring(response: 0.28, dampingFraction: 0.82)) {
+                        restingOffset = targetOffset(for: newValue)
+                    }
+                }
                 .onTapGesture {
-                    if offset < -12 {
+                    if isOpened {
                         withAnimation(.spring(response: 0.28, dampingFraction: 0.82)) {
-                            offset = 0
+                            openedRowID = nil
                         }
                     } else {
                         onTap()
@@ -37,8 +47,12 @@ struct RecordingRowView: View {
     }
 
     private var currentOffset: CGFloat {
-        let proposedOffset = offset + dragOffset
+        let proposedOffset = restingOffset + dragTranslation
         return min(0, max(-revealWidth, proposedOffset))
+    }
+
+    private var isOpened: Bool {
+        openedRowID == id
     }
 
     private var cardContent: some View {
@@ -103,34 +117,47 @@ struct RecordingRowView: View {
 
     private var dragGesture: some Gesture {
         DragGesture(minimumDistance: 10)
-            .onChanged { value in
-                dragOffset = value.translation.width
+            .updating($dragTranslation) { value, state, _ in
+                if value.translation.width < 0, openedRowID != nil, openedRowID != id {
+                    var transaction = Transaction()
+                    transaction.disablesAnimations = true
+                    withTransaction(transaction) {
+                        openedRowID = nil
+                    }
+                }
+                state = value.translation.width
             }
             .onEnded { value in
-                let current = min(0, max(-revealWidth, offset + value.translation.width))
+                let current = min(0, max(-revealWidth, restingOffset + value.translation.width))
+                let targetRowID: Recording.ID? = current < -revealWidth / 2 ? id : nil
 
                 var transaction = Transaction()
                 transaction.disablesAnimations = true
                 withTransaction(transaction) {
-                    offset = current
-                    dragOffset = 0
+                    restingOffset = current
                 }
 
-                withAnimation(.spring(response: 0.28, dampingFraction: 0.82)) {
-                    if current < -revealWidth / 2 {
-                        offset = -revealWidth
-                    } else {
-                        offset = 0
+                if targetRowID == openedRowID {
+                    withAnimation(.spring(response: 0.28, dampingFraction: 0.82)) {
+                        restingOffset = targetOffset(for: targetRowID)
                     }
+                } else {
+                    openedRowID = targetRowID
                 }
             }
+    }
+
+    private func targetOffset(for rowID: Recording.ID?) -> CGFloat {
+        rowID == id ? -revealWidth : 0
     }
 }
 
 #Preview {
     RecordingRowView(
+        id: URL(fileURLWithPath: "/tmp/preview.m4a"),
         title: "새로운 대화 기록 (4)",
         subtitle: "2026년 9월 2일 오후 6시 42분 • 49초",
+        openedRowID: .constant(nil),
         onTap: {}
     )
     .padding()

--- a/frontend/OnVoice/View/Components/RecordingRowView.swift
+++ b/frontend/OnVoice/View/Components/RecordingRowView.swift
@@ -5,6 +5,32 @@
 
 import SwiftUI
 
+enum RecordingRowSwipeBehavior {
+    static func baseOffset(
+        for openedRowID: Recording.ID?,
+        rowID: Recording.ID,
+        revealWidth: CGFloat
+    ) -> CGFloat {
+        openedRowID == rowID ? -revealWidth : 0
+    }
+
+    static func clampedOffset(
+        baseOffset: CGFloat,
+        translation: CGFloat,
+        revealWidth: CGFloat
+    ) -> CGFloat {
+        min(0, max(-revealWidth, baseOffset + translation))
+    }
+
+    static func targetOpenedRowID(
+        for currentOffset: CGFloat,
+        rowID: Recording.ID,
+        revealWidth: CGFloat
+    ) -> Recording.ID? {
+        currentOffset < -revealWidth / 2 ? rowID : nil
+    }
+}
+
 struct RecordingRowView: View {
     let id: Recording.ID
     let title: String
@@ -12,8 +38,12 @@ struct RecordingRowView: View {
     @Binding var openedRowID: Recording.ID?
     let onTap: () -> Void
 
-    @State private var restingOffset: CGFloat = 0
-    @GestureState private var dragTranslation: CGFloat = 0
+    @GestureState(
+        resetTransaction: Transaction(
+            animation: .spring(response: 0.28, dampingFraction: 0.82)
+        )
+    )
+    private var dragTranslation: CGFloat = 0
 
     private let revealWidth: CGFloat = 148
 
@@ -24,14 +54,6 @@ struct RecordingRowView: View {
             cardContent
                 .offset(x: currentOffset)
                 .gesture(dragGesture)
-                .onAppear {
-                    restingOffset = targetOffset(for: openedRowID)
-                }
-                .onChange(of: openedRowID) { newValue in
-                    withAnimation(.spring(response: 0.28, dampingFraction: 0.82)) {
-                        restingOffset = targetOffset(for: newValue)
-                    }
-                }
                 .onTapGesture {
                     if isOpened {
                         withAnimation(.spring(response: 0.28, dampingFraction: 0.82)) {
@@ -47,8 +69,19 @@ struct RecordingRowView: View {
     }
 
     private var currentOffset: CGFloat {
-        let proposedOffset = restingOffset + dragTranslation
-        return min(0, max(-revealWidth, proposedOffset))
+        RecordingRowSwipeBehavior.clampedOffset(
+            baseOffset: baseOffset,
+            translation: dragTranslation,
+            revealWidth: revealWidth
+        )
+    }
+
+    private var baseOffset: CGFloat {
+        RecordingRowSwipeBehavior.baseOffset(
+            for: openedRowID,
+            rowID: id,
+            revealWidth: revealWidth
+        )
     }
 
     private var isOpened: Bool {
@@ -118,37 +151,26 @@ struct RecordingRowView: View {
     private var dragGesture: some Gesture {
         DragGesture(minimumDistance: 10)
             .updating($dragTranslation) { value, state, _ in
-                if value.translation.width < 0, openedRowID != nil, openedRowID != id {
-                    var transaction = Transaction()
-                    transaction.disablesAnimations = true
-                    withTransaction(transaction) {
-                        openedRowID = nil
-                    }
-                }
                 state = value.translation.width
             }
             .onEnded { value in
-                let current = min(0, max(-revealWidth, restingOffset + value.translation.width))
-                let targetRowID: Recording.ID? = current < -revealWidth / 2 ? id : nil
+                let finalOffset = RecordingRowSwipeBehavior.clampedOffset(
+                    baseOffset: baseOffset,
+                    translation: value.translation.width,
+                    revealWidth: revealWidth
+                )
+                let targetRowID = RecordingRowSwipeBehavior.targetOpenedRowID(
+                    for: finalOffset,
+                    rowID: id,
+                    revealWidth: revealWidth
+                )
 
-                var transaction = Transaction()
-                transaction.disablesAnimations = true
-                withTransaction(transaction) {
-                    restingOffset = current
-                }
-
-                if targetRowID == openedRowID {
+                if targetRowID != openedRowID {
                     withAnimation(.spring(response: 0.28, dampingFraction: 0.82)) {
-                        restingOffset = targetOffset(for: targetRowID)
+                        openedRowID = targetRowID
                     }
-                } else {
-                    openedRowID = targetRowID
                 }
             }
-    }
-
-    private func targetOffset(for rowID: Recording.ID?) -> CGFloat {
-        rowID == id ? -revealWidth : 0
     }
 }
 

--- a/frontend/OnVoice/View/Components/RecordingRowView.swift
+++ b/frontend/OnVoice/View/Components/RecordingRowView.swift
@@ -6,6 +6,8 @@
 import SwiftUI
 
 enum RecordingRowSwipeBehavior {
+    static let snapAnimation = Animation.spring(response: 0.28, dampingFraction: 0.82)
+
     static func baseOffset(
         for openedRowID: Recording.ID?,
         rowID: Recording.ID,
@@ -42,7 +44,7 @@ struct RecordingRowView: View {
 
     @GestureState(
         resetTransaction: Transaction(
-            animation: .spring(response: 0.28, dampingFraction: 0.82)
+            animation: RecordingRowSwipeBehavior.snapAnimation
         )
     )
     private var dragTranslation: CGFloat = 0
@@ -58,7 +60,7 @@ struct RecordingRowView: View {
                 .gesture(dragGesture)
                 .onTapGesture {
                     if isOpened {
-                        withAnimation(.spring(response: 0.28, dampingFraction: 0.82)) {
+                        withAnimation(RecordingRowSwipeBehavior.snapAnimation) {
                             openedRowID = nil
                         }
                     } else {
@@ -168,7 +170,7 @@ struct RecordingRowView: View {
                 )
 
                 if targetRowID != openedRowID {
-                    withAnimation(.spring(response: 0.28, dampingFraction: 0.82)) {
+                    withAnimation(RecordingRowSwipeBehavior.snapAnimation) {
                         openedRowID = targetRowID
                     }
                 }

--- a/frontend/OnVoice/View/HomeView.swift
+++ b/frontend/OnVoice/View/HomeView.swift
@@ -86,12 +86,6 @@ struct HomeView: View {
             .navigationDestination(item: $selectedRecording) { recording in
                 AnalysisSummaryView(recording: recording)
             }
-            .onAppear {
-                resetSwipeState()
-            }
-            .onDisappear {
-                resetSwipeState()
-            }
             .onChange(of: selectedTab) { _ in
                 resetSwipeState()
             }

--- a/frontend/OnVoice/View/HomeView.swift
+++ b/frontend/OnVoice/View/HomeView.swift
@@ -87,23 +87,23 @@ struct HomeView: View {
                 AnalysisSummaryView(recording: recording)
             }
             .onChange(of: selectedTab) { _ in
-                resetSwipeState()
+                closeOpenedRowIfNeeded()
             }
             .onChange(of: isShowingSituationRecognition) { isPresented in
                 if isPresented {
-                    resetSwipeState()
+                    closeOpenedRowIfNeeded()
                 }
             }
             .onChange(of: selectedRecording) { _ in
-                resetSwipeState()
+                closeOpenedRowIfNeeded()
             }
         }
     }
 
-    private func resetSwipeState() {
+    private func closeOpenedRowIfNeeded() {
         guard openedRowID != nil else { return }
 
-        withAnimation(.spring(response: 0.28, dampingFraction: 0.82)) {
+        withAnimation(RecordingRowSwipeBehavior.snapAnimation) {
             openedRowID = nil
         }
     }

--- a/frontend/OnVoice/View/HomeView.swift
+++ b/frontend/OnVoice/View/HomeView.swift
@@ -94,16 +94,18 @@ struct HomeView: View {
                     resetSwipeState()
                 }
             }
-            .onChange(of: selectedRecording) { recording in
-                if recording != nil {
-                    resetSwipeState()
-                }
+            .onChange(of: selectedRecording) { _ in
+                resetSwipeState()
             }
         }
     }
 
     private func resetSwipeState() {
-        openedRowID = nil
+        guard openedRowID != nil else { return }
+
+        withAnimation(.spring(response: 0.28, dampingFraction: 0.82)) {
+            openedRowID = nil
+        }
     }
 
     private func todayDateString() -> String {

--- a/frontend/OnVoice/View/HomeView.swift
+++ b/frontend/OnVoice/View/HomeView.swift
@@ -12,6 +12,7 @@ struct HomeView: View {
     @Binding var selectedTab: OnVoiceTab
     @State private var isShowingSituationRecognition = false
     @State private var selectedRecording: Recording?
+    @State private var openedRowID: Recording.ID?
 
     private var displayedRecordings: [(index: Int, recording: Recording)] {
         Array(recorder.recordings.reversed().enumerated()).map { offset, recording in
@@ -50,8 +51,10 @@ struct HomeView: View {
                                     VStack(spacing: 16) {
                                         ForEach(displayedRecordings, id: \.recording.id) { item in
                                             RecordingRowView(
+                                                id: item.recording.id,
                                                 title: "새로운 대화 기록 (\(item.index))",
                                                 subtitle: "\(item.recording.formattedDate) • \(item.recording.formattedDuration)",
+                                                openedRowID: $openedRowID,
                                                 onTap: {
                                                     selectedRecording = item.recording
                                                 }
@@ -83,7 +86,30 @@ struct HomeView: View {
             .navigationDestination(item: $selectedRecording) { recording in
                 AnalysisSummaryView(recording: recording)
             }
+            .onAppear {
+                resetSwipeState()
+            }
+            .onDisappear {
+                resetSwipeState()
+            }
+            .onChange(of: selectedTab) { _ in
+                resetSwipeState()
+            }
+            .onChange(of: isShowingSituationRecognition) { isPresented in
+                if isPresented {
+                    resetSwipeState()
+                }
+            }
+            .onChange(of: selectedRecording) { recording in
+                if recording != nil {
+                    resetSwipeState()
+                }
+            }
         }
+    }
+
+    private func resetSwipeState() {
+        openedRowID = nil
     }
 
     private func todayDateString() -> String {

--- a/frontend/OnVoiceTests/RecordingRowSwipeBehaviorTests.swift
+++ b/frontend/OnVoiceTests/RecordingRowSwipeBehaviorTests.swift
@@ -56,9 +56,9 @@ final class RecordingRowSwipeBehaviorTests: XCTestCase {
         )
     }
 
-    func testTargetOpenedRowIDOpensOnlyPastHalfThreshold() {
+    func testResolvedOpenedRowIDOpensOnlyPastHalfThreshold() {
         XCTAssertEqual(
-            RecordingRowSwipeBehavior.targetOpenedRowID(
+            RecordingRowSwipeBehavior.resolvedOpenedRowID(
                 for: -90,
                 rowID: rowID,
                 revealWidth: revealWidth
@@ -67,8 +67,18 @@ final class RecordingRowSwipeBehaviorTests: XCTestCase {
         )
 
         XCTAssertNil(
-            RecordingRowSwipeBehavior.targetOpenedRowID(
+            RecordingRowSwipeBehavior.resolvedOpenedRowID(
                 for: -(revealWidth / 2),
+                rowID: rowID,
+                revealWidth: revealWidth
+            )
+        )
+    }
+
+    func testResolvedOpenedRowIDClosesWhenDragReturnsPastThreshold() {
+        XCTAssertNil(
+            RecordingRowSwipeBehavior.resolvedOpenedRowID(
+                for: -40,
                 rowID: rowID,
                 revealWidth: revealWidth
             )
@@ -89,7 +99,7 @@ final class RecordingRowSwipeBehaviorTests: XCTestCase {
 
         XCTAssertEqual(finalOffset, -100)
         XCTAssertEqual(
-            RecordingRowSwipeBehavior.targetOpenedRowID(
+            RecordingRowSwipeBehavior.resolvedOpenedRowID(
                 for: finalOffset,
                 rowID: rowID,
                 revealWidth: revealWidth

--- a/frontend/OnVoiceTests/RecordingRowSwipeBehaviorTests.swift
+++ b/frontend/OnVoiceTests/RecordingRowSwipeBehaviorTests.swift
@@ -1,0 +1,100 @@
+import CoreGraphics
+import XCTest
+@testable import OnVoice
+
+final class RecordingRowSwipeBehaviorTests: XCTestCase {
+    private let rowID = URL(fileURLWithPath: "/tmp/row.m4a")
+    private let otherRowID = URL(fileURLWithPath: "/tmp/other-row.m4a")
+    private let revealWidth: CGFloat = 148
+
+    func testBaseOffsetUsesOpenedRowIDAsSingleSourceOfTruth() {
+        XCTAssertEqual(
+            RecordingRowSwipeBehavior.baseOffset(
+                for: rowID,
+                rowID: rowID,
+                revealWidth: revealWidth
+            ),
+            -revealWidth
+        )
+
+        XCTAssertEqual(
+            RecordingRowSwipeBehavior.baseOffset(
+                for: otherRowID,
+                rowID: rowID,
+                revealWidth: revealWidth
+            ),
+            0
+        )
+
+        XCTAssertEqual(
+            RecordingRowSwipeBehavior.baseOffset(
+                for: nil,
+                rowID: rowID,
+                revealWidth: revealWidth
+            ),
+            0
+        )
+    }
+
+    func testClampedOffsetStaysWithinRevealWidth() {
+        XCTAssertEqual(
+            RecordingRowSwipeBehavior.clampedOffset(
+                baseOffset: 0,
+                translation: -220,
+                revealWidth: revealWidth
+            ),
+            -revealWidth
+        )
+
+        XCTAssertEqual(
+            RecordingRowSwipeBehavior.clampedOffset(
+                baseOffset: -revealWidth,
+                translation: 220,
+                revealWidth: revealWidth
+            ),
+            0
+        )
+    }
+
+    func testTargetOpenedRowIDOpensOnlyPastHalfThreshold() {
+        XCTAssertEqual(
+            RecordingRowSwipeBehavior.targetOpenedRowID(
+                for: -90,
+                rowID: rowID,
+                revealWidth: revealWidth
+            ),
+            rowID
+        )
+
+        XCTAssertNil(
+            RecordingRowSwipeBehavior.targetOpenedRowID(
+                for: -(revealWidth / 2),
+                rowID: rowID,
+                revealWidth: revealWidth
+            )
+        )
+    }
+
+    func testDifferentOpenRowStillLetsNewRowComputeFromClosedBaseline() {
+        let baseOffset = RecordingRowSwipeBehavior.baseOffset(
+            for: otherRowID,
+            rowID: rowID,
+            revealWidth: revealWidth
+        )
+        let finalOffset = RecordingRowSwipeBehavior.clampedOffset(
+            baseOffset: baseOffset,
+            translation: -100,
+            revealWidth: revealWidth
+        )
+
+        XCTAssertEqual(finalOffset, -100)
+        XCTAssertEqual(
+            RecordingRowSwipeBehavior.targetOpenedRowID(
+                for: finalOffset,
+                rowID: rowID,
+                revealWidth: revealWidth
+            ),
+            rowID
+        )
+    }
+}


### PR DESCRIPTION
## Summary
홈 화면 기록 리스트의 스와이프 동작을 개선했습니다.
한 번에 하나의 항목만 열리도록 스와이프 상태를 단일화했고, 홈 화면을 벗어나는 경우에는 열린 스와이프가 초기화되도록 수정했습니다.

## Related Issue
- issue: #30  

## Changes (변경 사항)
- 홈 기록 리스트에서 동시에 여러 항목이 스와이프되지 않도록 열린 행 상태를 하나만 관리하도록 수정
- 다른 항목을 스와이프하면 기존에 열려 있던 항목이 자동으로 닫히도록 처리
- `+` 이동, 탭 전환, 상세 화면 진입, 홈 화면 재진입 시 스와이프 상태가 초기화되도록 반영
- 드래그 중간 위치가 고정되는 문제와 스와이프 애니메이션이 두 번 보이는 문제를 개선

## Test
- [x] 로컬에서 테스트 완료
- [x] 기존 기능에 영향 없음

## Screenshots (Optional)
| 변경 전 | 변경 후 |
|---|---|
|<img width="784" height="1706" alt="image" src="https://github.com/user-attachments/assets/c6ec3f39-b612-496b-a57f-347c87f34825" />|<img width="784" height="1706" alt="image" src="https://github.com/user-attachments/assets/5848b60a-9ae5-400f-8310-4d2284514930" />|
| 여러 항목이 동시에 부분 스와이프된 상태로 남음 | 한 번에 하나의 항목만 열리고 홈 이탈 시 초기화됨 |

## Checklist
- [x] 변경사항 400줄 이하
- [ ] 필요시 테스트 추가
- [ ] 필요시 문서 업데이트

## Additional Context (추가 사항)
- 홈 화면 리스트의 스와이프 상태를 부모 뷰에서 관리하도록 구조를 조정했습니다.
- 임시 드래그 값과 실제 열린 상태를 분리해 스와이프 동작의 일관성을 높였습니다.