### PR TITLE
feat: 홈 기록 리스트 스와이프 수정/삭제 기능 추가

### DIFF
--- a/frontend/OnVoice/Service/AudioRecord.swift
+++ b/frontend/OnVoice/Service/AudioRecord.swift
@@ -23,10 +23,7 @@ struct Recording: Identifiable, Hashable {
     }
 
     var usesGeneratedDefaultTitle: Bool {
-        Self.generatedTitlePattern.firstMatch(
-            in: title,
-            range: NSRange(title.startIndex..., in: title)
-        ) != nil
+        title.wholeMatch(of: /^Recording_\d{8}_\d{6}$/) != nil
     }
     
     var formattedDate: String {
@@ -42,9 +39,6 @@ struct Recording: Identifiable, Hashable {
         return "\(minutes)분 \(seconds)초"
     }
 
-    private static let generatedTitlePattern = try! NSRegularExpression(
-        pattern: #"^Recording_\d{8}_\d{6}$"#
-    )
 }
 
 class AudioRecorder: ObservableObject {
@@ -52,6 +46,23 @@ class AudioRecorder: ObservableObject {
     
     private var recorder: AVAudioRecorder?
     private var startTime: Date?
+
+    enum RecordingMutationError: LocalizedError {
+        case recordingNotFound
+        case invalidTitle
+        case fileOperationFailed(underlying: Error)
+
+        var errorDescription: String? {
+            switch self {
+            case .recordingNotFound:
+                return "대상 녹음을 찾을 수 없어요."
+            case .invalidTitle:
+                return "녹음 이름을 다시 확인해 주세요."
+            case let .fileOperationFailed(underlying):
+                return "파일 작업에 실패했어요. \(underlying.localizedDescription)"
+            }
+        }
+    }
     
     func start() {
         let audioSession = AVAudioSession.sharedInstance()
@@ -91,35 +102,37 @@ class AudioRecorder: ObservableObject {
         }
     }
 
-    func deleteRecording(_ recording: Recording) {
+    func deleteRecording(_ recording: Recording) throws {
+        guard let index = recordings.firstIndex(where: { $0.id == recording.id }) else {
+            throw RecordingMutationError.recordingNotFound
+        }
+
         do {
             if FileManager.default.fileExists(atPath: recording.fileURL.path) {
                 try FileManager.default.removeItem(at: recording.fileURL)
             }
-            recordings.removeAll { $0.id == recording.id }
+            recordings.remove(at: index)
         } catch {
-            print("녹음 파일 삭제 실패: \(error)")
+            throw RecordingMutationError.fileOperationFailed(underlying: error)
         }
     }
 
     @discardableResult
-    func renameRecording(_ recording: Recording, to newTitle: String) -> Recording? {
+    func renameRecording(_ recording: Recording, to newTitle: String) throws -> Recording {
         let sanitizedTitle = Self.sanitizedRecordingTitle(from: newTitle)
-        guard !sanitizedTitle.isEmpty else { return nil }
+        guard !sanitizedTitle.isEmpty else {
+            throw RecordingMutationError.invalidTitle
+        }
+
+        guard let index = recordings.firstIndex(where: { $0.id == recording.id }) else {
+            throw RecordingMutationError.recordingNotFound
+        }
 
         let destinationURL = uniqueRecordingURL(for: recording, sanitizedTitle: sanitizedTitle)
         guard destinationURL != recording.fileURL else { return recording }
 
         do {
             try FileManager.default.moveItem(at: recording.fileURL, to: destinationURL)
-
-            guard let index = recordings.firstIndex(where: { $0.id == recording.id }) else {
-                return Recording(
-                    fileURL: destinationURL,
-                    createdAt: recording.createdAt,
-                    duration: recording.duration
-                )
-            }
 
             let updatedRecording = Recording(
                 fileURL: destinationURL,
@@ -129,8 +142,7 @@ class AudioRecorder: ObservableObject {
             recordings[index] = updatedRecording
             return updatedRecording
         } catch {
-            print("녹음 파일 이름 변경 실패: \(error)")
-            return nil
+            throw RecordingMutationError.fileOperationFailed(underlying: error)
         }
     }
 

--- a/frontend/OnVoice/Service/AudioRecord.swift
+++ b/frontend/OnVoice/Service/AudioRecord.swift
@@ -21,6 +21,13 @@ struct Recording: Identifiable, Hashable {
     var title: String {
         return fileURL.deletingPathExtension().lastPathComponent
     }
+
+    var usesGeneratedDefaultTitle: Bool {
+        Self.generatedTitlePattern.firstMatch(
+            in: title,
+            range: NSRange(title.startIndex..., in: title)
+        ) != nil
+    }
     
     var formattedDate: String {
         let formatter = DateFormatter()
@@ -34,6 +41,10 @@ struct Recording: Identifiable, Hashable {
         let seconds = Int(duration) % 60
         return "\(minutes)분 \(seconds)초"
     }
+
+    private static let generatedTitlePattern = try! NSRegularExpression(
+        pattern: #"^Recording_\d{8}_\d{6}$"#
+    )
 }
 
 class AudioRecorder: ObservableObject {

--- a/frontend/OnVoice/Service/AudioRecord.swift
+++ b/frontend/OnVoice/Service/AudioRecord.swift
@@ -79,6 +79,61 @@ class AudioRecorder: ObservableObject {
             recordings.append(recording)
         }
     }
+
+    func deleteRecording(_ recording: Recording) {
+        do {
+            if FileManager.default.fileExists(atPath: recording.fileURL.path) {
+                try FileManager.default.removeItem(at: recording.fileURL)
+            }
+            recordings.removeAll { $0.id == recording.id }
+        } catch {
+            print("녹음 파일 삭제 실패: \(error)")
+        }
+    }
+
+    @discardableResult
+    func renameRecording(_ recording: Recording, to newTitle: String) -> Recording? {
+        let sanitizedTitle = Self.sanitizedRecordingTitle(from: newTitle)
+        guard !sanitizedTitle.isEmpty else { return nil }
+
+        let destinationURL = uniqueRecordingURL(for: recording, sanitizedTitle: sanitizedTitle)
+        guard destinationURL != recording.fileURL else { return recording }
+
+        do {
+            try FileManager.default.moveItem(at: recording.fileURL, to: destinationURL)
+
+            guard let index = recordings.firstIndex(where: { $0.id == recording.id }) else {
+                return Recording(
+                    fileURL: destinationURL,
+                    createdAt: recording.createdAt,
+                    duration: recording.duration
+                )
+            }
+
+            let updatedRecording = Recording(
+                fileURL: destinationURL,
+                createdAt: recording.createdAt,
+                duration: recording.duration
+            )
+            recordings[index] = updatedRecording
+            return updatedRecording
+        } catch {
+            print("녹음 파일 이름 변경 실패: \(error)")
+            return nil
+        }
+    }
+
+    static func sanitizedRecordingTitle(from rawTitle: String) -> String {
+        let invalidCharacters = CharacterSet(charactersIn: "/\\:?%*|\"<>")
+        let components = rawTitle
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .components(separatedBy: invalidCharacters)
+
+        return components
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
     
     /// m4a 파일에서 실제 재생 길이 측정
     private func getAccurateAudioDuration(from url: URL) -> TimeInterval {
@@ -97,6 +152,24 @@ class AudioRecorder: ObservableObject {
         let filename = "Recording_\(formatter.string(from: Date())).m4a"
         let path = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
         return path.appendingPathComponent(filename)
+    }
+
+    private func uniqueRecordingURL(for recording: Recording, sanitizedTitle: String) -> URL {
+        let directoryURL = recording.fileURL.deletingLastPathComponent()
+        let fileExtension = recording.fileURL.pathExtension
+        var candidateURL = directoryURL.appendingPathComponent(sanitizedTitle).appendingPathExtension(fileExtension)
+        var suffix = 2
+
+        while candidateURL != recording.fileURL,
+              FileManager.default.fileExists(atPath: candidateURL.path) {
+            let disambiguatedTitle = "\(sanitizedTitle) (\(suffix))"
+            candidateURL = directoryURL
+                .appendingPathComponent(disambiguatedTitle)
+                .appendingPathExtension(fileExtension)
+            suffix += 1
+        }
+
+        return candidateURL
     }
 }
 

--- a/frontend/OnVoice/View/Components/RecordingRowView.swift
+++ b/frontend/OnVoice/View/Components/RecordingRowView.swift
@@ -41,6 +41,8 @@ struct RecordingRowView: View {
     let subtitle: String
     @Binding var openedRowID: Recording.ID?
     let onTap: () -> Void
+    let onEdit: () -> Void
+    let onDelete: () -> Void
 
     @GestureState(
         resetTransaction: Transaction(
@@ -123,33 +125,54 @@ struct RecordingRowView: View {
             actionButton(
                 systemImage: "pencil",
                 title: "수정",
-                fillColor: Color(uiColor: .systemIndigo)
+                fillColor: Color(uiColor: .systemIndigo),
+                action: {
+                    withAnimation(RecordingRowSwipeBehavior.snapAnimation) {
+                        openedRowID = nil
+                    }
+                    onEdit()
+                }
             )
 
             actionButton(
                 systemImage: "trash",
                 title: "삭제",
-                fillColor: Color(uiColor: .systemRed)
+                fillColor: Color(uiColor: .systemRed),
+                action: {
+                    withAnimation(RecordingRowSwipeBehavior.snapAnimation) {
+                        openedRowID = nil
+                    }
+                    onDelete()
+                }
             )
         }
         .padding(.trailing, 8)
     }
 
-    private func actionButton(systemImage: String, title: String, fillColor: Color) -> some View {
-        VStack(spacing: 4) {
-            Circle()
-                .fill(fillColor)
-                .frame(width: 42, height: 42)
-                .overlay {
-                    Image(systemName: systemImage)
-                        .font(.system(size: 17, weight: .semibold))
-                        .foregroundStyle(.white)
-                }
+    private func actionButton(
+        systemImage: String,
+        title: String,
+        fillColor: Color,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            VStack(spacing: 4) {
+                Circle()
+                    .fill(fillColor)
+                    .frame(width: 42, height: 42)
+                    .overlay {
+                        Image(systemName: systemImage)
+                            .font(.system(size: 17, weight: .semibold))
+                            .foregroundStyle(.white)
+                    }
 
-            Text(title)
-                .onVoiceTextStyle(.caption1, color: .gray5)
+                Text(title)
+                    .onVoiceTextStyle(.caption1, color: .gray5)
+            }
+            .frame(width: 48)
+            .contentShape(Rectangle())
         }
-        .frame(width: 48)
+        .buttonStyle(.plain)
     }
 
     private var dragGesture: some Gesture {
@@ -184,7 +207,9 @@ struct RecordingRowView: View {
         title: "새로운 대화 기록 (4)",
         subtitle: "2026년 9월 2일 오후 6시 42분 • 49초",
         openedRowID: .constant(nil),
-        onTap: {}
+        onTap: {},
+        onEdit: {},
+        onDelete: {}
     )
     .padding()
     .background(Color.bg)

--- a/frontend/OnVoice/View/HomeView.swift
+++ b/frontend/OnVoice/View/HomeView.swift
@@ -13,6 +13,10 @@ struct HomeView: View {
     @State private var isShowingSituationRecognition = false
     @State private var selectedRecording: Recording?
     @State private var openedRowID: Recording.ID?
+    @State private var recordingToRename: Recording?
+    @State private var pendingRecordingTitle = ""
+    @State private var recordingToDelete: Recording?
+    @State private var deletePromptTitle = ""
 
     private var displayedRecordings: [(index: Int, recording: Recording)] {
         Array(recorder.recordings.reversed().enumerated()).map { offset, recording in
@@ -50,13 +54,21 @@ struct HomeView: View {
                                 ScrollView(showsIndicators: false) {
                                     VStack(spacing: 16) {
                                         ForEach(displayedRecordings, id: \.recording.id) { item in
+                                            let displayTitle = title(for: item.recording, index: item.index)
                                             RecordingRowView(
                                                 id: item.recording.id,
-                                                title: "새로운 대화 기록 (\(item.index))",
+                                                title: displayTitle,
                                                 subtitle: "\(item.recording.formattedDate) • \(item.recording.formattedDuration)",
                                                 openedRowID: $openedRowID,
                                                 onTap: {
                                                     selectedRecording = item.recording
+                                                },
+                                                onEdit: {
+                                                    beginRenaming(item.recording, suggestedTitle: displayTitle)
+                                                },
+                                                onDelete: {
+                                                    recordingToDelete = item.recording
+                                                    deletePromptTitle = displayTitle
                                                 }
                                             )
                                         }
@@ -97,6 +109,33 @@ struct HomeView: View {
             .onChange(of: selectedRecording) { _ in
                 closeOpenedRowIfNeeded()
             }
+            .alert("녹음 이름 수정", isPresented: renameAlertIsPresented) {
+                TextField("녹음 이름", text: $pendingRecordingTitle)
+
+                Button("취소", role: .cancel) {
+                    clearRenameState()
+                }
+
+                Button("저장") {
+                    commitRename()
+                }
+            } message: {
+                Text("녹음 파일 이름을 바꾸면 홈 화면 리스트 제목도 함께 변경됩니다.")
+            }
+            .alert("녹음 삭제", isPresented: deleteAlertIsPresented, presenting: recordingToDelete) { recording in
+                Button("취소", role: .cancel) {
+                    recordingToDelete = nil
+                    deletePromptTitle = ""
+                }
+
+                Button("삭제", role: .destructive) {
+                    recorder.deleteRecording(recording)
+                    recordingToDelete = nil
+                    deletePromptTitle = ""
+                }
+            } message: { recording in
+                Text("'\(deletePromptTitle)' 녹음을 삭제할까요?")
+            }
         }
     }
 
@@ -106,6 +145,57 @@ struct HomeView: View {
         withAnimation(RecordingRowSwipeBehavior.snapAnimation) {
             openedRowID = nil
         }
+    }
+
+    private var renameAlertIsPresented: Binding<Bool> {
+        Binding(
+            get: { recordingToRename != nil },
+            set: { isPresented in
+                if !isPresented {
+                    clearRenameState()
+                }
+            }
+        )
+    }
+
+    private var deleteAlertIsPresented: Binding<Bool> {
+        Binding(
+            get: { recordingToDelete != nil },
+            set: { isPresented in
+                if !isPresented {
+                    recordingToDelete = nil
+                    deletePromptTitle = ""
+                }
+            }
+        )
+    }
+
+    private func beginRenaming(_ recording: Recording, suggestedTitle: String) {
+        recordingToRename = recording
+        pendingRecordingTitle = suggestedTitle
+    }
+
+    private func clearRenameState() {
+        recordingToRename = nil
+        pendingRecordingTitle = ""
+    }
+
+    private func commitRename() {
+        guard let recordingToRename else { return }
+
+        let updatedRecording = recorder.renameRecording(recordingToRename, to: pendingRecordingTitle)
+        if let updatedRecording, selectedRecording?.id == recordingToRename.id {
+            selectedRecording = updatedRecording
+        }
+        clearRenameState()
+    }
+
+    private func title(for recording: Recording, index: Int) -> String {
+        if recording.title.hasPrefix("Recording_") {
+            return "새로운 대화 기록 (\(index))"
+        }
+
+        return recording.title
     }
 
     private func todayDateString() -> String {

--- a/frontend/OnVoice/View/HomeView.swift
+++ b/frontend/OnVoice/View/HomeView.swift
@@ -14,9 +14,11 @@ struct HomeView: View {
     @State private var selectedRecording: Recording?
     @State private var openedRowID: Recording.ID?
     @State private var recordingToRename: Recording?
+    @State private var originalPendingRecordingTitle = ""
     @State private var pendingRecordingTitle = ""
     @State private var recordingToDelete: Recording?
     @State private var deletePromptTitle = ""
+    @State private var mutationErrorMessage = ""
 
     private var displayedRecordings: [(index: Int, recording: Recording)] {
         Array(recorder.recordings.reversed().enumerated()).map { offset, recording in
@@ -67,6 +69,7 @@ struct HomeView: View {
                                                     beginRenaming(item.recording, suggestedTitle: displayTitle)
                                                 },
                                                 onDelete: {
+                                                    clearRenameState()
                                                     recordingToDelete = item.recording
                                                     deletePromptTitle = displayTitle
                                                 }
@@ -134,15 +137,17 @@ struct HomeView: View {
                 }
 
                 Button("삭제", role: .destructive) {
-                    if selectedRecording?.id == recording.id {
-                        selectedRecording = nil
-                    }
-                    recorder.deleteRecording(recording)
-                    recordingToDelete = nil
-                    deletePromptTitle = ""
+                    commitDelete(recording)
                 }
             } message: { recording in
                 Text("'\(deletePromptTitle)' 녹음을 삭제할까요?")
+            }
+            .alert("작업 실패", isPresented: mutationErrorIsPresented) {
+                Button("확인", role: .cancel) {
+                    mutationErrorMessage = ""
+                }
+            } message: {
+                Text(mutationErrorMessage)
             }
         }
     }
@@ -178,24 +183,69 @@ struct HomeView: View {
         )
     }
 
+    private var mutationErrorIsPresented: Binding<Bool> {
+        Binding(
+            get: { !mutationErrorMessage.isEmpty },
+            set: { isPresented in
+                if !isPresented {
+                    mutationErrorMessage = ""
+                }
+            }
+        )
+    }
+
     private func beginRenaming(_ recording: Recording, suggestedTitle: String) {
+        recordingToDelete = nil
+        deletePromptTitle = ""
         recordingToRename = recording
+        originalPendingRecordingTitle = suggestedTitle
         pendingRecordingTitle = suggestedTitle
     }
 
     private func clearRenameState() {
         recordingToRename = nil
+        originalPendingRecordingTitle = ""
         pendingRecordingTitle = ""
     }
 
     private func commitRename() {
         guard let recordingToRename else { return }
 
-        let updatedRecording = recorder.renameRecording(recordingToRename, to: pendingRecordingTitle)
-        if let updatedRecording, selectedRecording?.id == recordingToRename.id {
-            selectedRecording = updatedRecording
+        if recordingToRename.usesGeneratedDefaultTitle,
+           pendingRecordingTitle == originalPendingRecordingTitle {
+            clearRenameState()
+            return
         }
-        clearRenameState()
+
+        do {
+            let updatedRecording = try recorder.renameRecording(recordingToRename, to: pendingRecordingTitle)
+            if selectedRecording?.id == recordingToRename.id {
+                selectedRecording = updatedRecording
+            }
+            clearRenameState()
+        } catch {
+            clearRenameState()
+            presentMutationError(error)
+        }
+    }
+
+    private func commitDelete(_ recording: Recording) {
+        do {
+            try recorder.deleteRecording(recording)
+            if selectedRecording?.id == recording.id {
+                selectedRecording = nil
+            }
+            recordingToDelete = nil
+            deletePromptTitle = ""
+        } catch {
+            recordingToDelete = nil
+            deletePromptTitle = ""
+            presentMutationError(error)
+        }
+    }
+
+    private func presentMutationError(_ error: Error) {
+        mutationErrorMessage = error.localizedDescription
     }
 
     private func title(for recording: Recording, index: Int) -> String {

--- a/frontend/OnVoice/View/HomeView.swift
+++ b/frontend/OnVoice/View/HomeView.swift
@@ -84,6 +84,11 @@ struct HomeView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
                 }
             }
+            .simultaneousGesture(
+                TapGesture().onEnded {
+                    closeOpenedRowIfNeeded()
+                }
+            )
             .safeAreaInset(edge: .bottom, spacing: 0) {
                 BottomDockView(
                     selectedTab: $selectedTab,

--- a/frontend/OnVoice/View/HomeView.swift
+++ b/frontend/OnVoice/View/HomeView.swift
@@ -134,6 +134,9 @@ struct HomeView: View {
                 }
 
                 Button("삭제", role: .destructive) {
+                    if selectedRecording?.id == recording.id {
+                        selectedRecording = nil
+                    }
                     recorder.deleteRecording(recording)
                     recordingToDelete = nil
                     deletePromptTitle = ""
@@ -196,7 +199,7 @@ struct HomeView: View {
     }
 
     private func title(for recording: Recording, index: Int) -> String {
-        if recording.title.hasPrefix("Recording_") {
+        if recording.usesGeneratedDefaultTitle {
             return "새로운 대화 기록 (\(index))"
         }
 


### PR DESCRIPTION
## Summary
홈 화면 기록 리스트의 스와이프 액션에 수정/삭제 기능을 추가했습니다.
기존에 자리만 있던 액션을 실제 동작으로 연결했고, 스와이프된 항목이 열린 상태에서 배경을 탭하면 닫히도록 예외 처리도 보완했습니다.

## Related Issue
- issue: #29  

## Changes (변경 사항)
- 홈 기록 리스트의 스와이프 `수정` 액션을 실제 이름 변경 기능과 연결
- 이름 변경 시 alert를 통해 바로 수정할 수 있도록 UI 추가
- 홈 리스트에서는 기본 제목 `새로운 대화 기록 (n)` 형식을 유지하고, 사용자가 수정한 경우에만 변경된 이름이 보이도록 처리
- 스와이프 `삭제` 액션을 실제 녹음 데이터 삭제와 연결
- 수정/삭제 버튼 탭 시 열린 row가 자연스럽게 닫히도록 보완
- 스와이프된 row가 열린 상태에서 배경을 탭하면 스와이프가 해제되도록 예외 상황 처리 추가
- 삭제 확인 alert 문구가 현재 리스트 표시명과 일치하도록 정리

## Test
- [x] 로컬에서 테스트 완료
- [x] 기존 기능에 영향 없음

## Screenshots (Optional)
| 수정 | 수정 완료 후 삭제 | 삭제 완료 |
|:--:|:--:|:--:|
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-14 at 14 18 33" src="https://github.com/user-attachments/assets/9a449a09-c27a-44dc-a6da-6e6c25c2ea8b" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-14 at 14 18 53" src="https://github.com/user-attachments/assets/46becc35-0a35-4097-9d49-e59ed3287d3b" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-14 at 14 19 13" src="https://github.com/user-attachments/assets/05f15556-fc8a-483e-862c-77bc9c8e7ed2" /> |




## Checklist
- [x] 변경사항 400줄 이하
- [ ] 필요시 테스트 추가
- [ ] 필요시 문서 업데이트

## Additional Context (추가 사항)
- 이번 PR 범위는 홈 화면 리스트의 스와이프 인터랙션과 녹음 이름 수정/삭제 동작 연결에 한정됩니다.