### PR TITLE
feat: 라이브러리 헤더 Figma와 UI 홈 화면 기준으로 정렬

### DIFF
--- a/frontend/OnVoice/View/Components/HomeHeaderView.swift
+++ b/frontend/OnVoice/View/Components/HomeHeaderView.swift
@@ -8,7 +8,10 @@ import SwiftUI
 struct HomeHeaderView: View {
     let title: String
     var showsProfileButton: Bool = true
+    var showsTitleTrailingButton: Bool = false
     private let headerHeight: CGFloat = 152
+    private let titleTopPadding: CGFloat = 70
+    private let titleTrailingButtonTopPadding: CGFloat = 105
 
     var body: some View {
         ZStack(alignment: .top) {
@@ -51,7 +54,20 @@ struct HomeHeaderView: View {
                 Text(title)
                     .onVoiceTextStyle(.head2, color: .sub)
                     .padding(.leading, 18)
-                    .padding(.top, 70)
+                    .padding(.top, titleTopPadding)
+
+                if showsTitleTrailingButton {
+                    Button {} label: {
+                        Image(systemName: "ellipsis")
+                            .font(.system(size: 22, weight: .semibold))
+                            .foregroundColor(.gray6)
+                            .frame(width: 44, height: 28)
+                    }
+                    .buttonStyle(.plain)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
+                    .padding(.trailing, 18)
+                    .padding(.top, titleTrailingButtonTopPadding)
+                }
 
                 if showsProfileButton {
                     Button {} label: {

--- a/frontend/OnVoice/View/Components/HomeHeaderView.swift
+++ b/frontend/OnVoice/View/Components/HomeHeaderView.swift
@@ -8,10 +8,13 @@ import SwiftUI
 struct HomeHeaderView: View {
     let title: String
     var showsProfileButton: Bool = true
-    var showsTitleTrailingButton: Bool = false
+    var titleTopOffset: CGFloat = 0
     private let headerHeight: CGFloat = 152
-    private let titleTopPadding: CGFloat = 70
-    private let titleTrailingButtonTopPadding: CGFloat = 105
+    private let horizontalPadding: CGFloat = 18
+    private let logoTopPadding: CGFloat = 22
+    private let profileButtonTopPadding: CGFloat = 18
+    private let headerContentSpacing: CGFloat = 24
+    var onTitleTrailingButtonTap: (() -> Void)? = nil
 
     var body: some View {
         ZStack(alignment: .top) {
@@ -44,30 +47,33 @@ struct HomeHeaderView: View {
                 .ignoresSafeArea(edges: .top)
 
             ZStack(alignment: .topLeading) {
-                Image("logo")
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 24, height: 24)
-                    .padding(.leading, 18)
-                    .padding(.top, 22)
+                VStack(alignment: .leading, spacing: headerContentSpacing) {
+                    Image("logo")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 24, height: 24)
 
-                Text(title)
-                    .onVoiceTextStyle(.head2, color: .sub)
-                    .padding(.leading, 18)
-                    .padding(.top, titleTopPadding)
+                    HStack(alignment: .top, spacing: 12) {
+                        Text(title)
+                            .onVoiceTextStyle(.head2, color: .sub)
+                            .frame(maxWidth: .infinity, alignment: .leading)
 
-                if showsTitleTrailingButton {
-                    Button {} label: {
-                        Image(systemName: "ellipsis")
-                            .font(.system(size: 22, weight: .semibold))
-                            .foregroundColor(.gray6)
-                            .frame(width: 44, height: 28)
+                        if let onTitleTrailingButtonTap {
+                            Button(action: onTitleTrailingButtonTap) {
+                                Image(systemName: "ellipsis")
+                                    .font(.system(size: 22, weight: .semibold))
+                                    .foregroundColor(.gray6)
+                                    .frame(width: 44, height: 28)
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("추가 옵션")
+                        }
                     }
-                    .buttonStyle(.plain)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
-                    .padding(.trailing, 18)
-                    .padding(.top, titleTrailingButtonTopPadding)
+                    .padding(.top, titleTopOffset)
                 }
+                .padding(.top, logoTopPadding)
+                .padding(.horizontal, horizontalPadding)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
 
                 if showsProfileButton {
                     Button {} label: {
@@ -83,8 +89,8 @@ struct HomeHeaderView: View {
                     }
                     .buttonStyle(.plain)
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
-                    .padding(.trailing, 18)
-                    .padding(.top, 18)
+                    .padding(.trailing, horizontalPadding)
+                    .padding(.top, profileButtonTopPadding)
                 }
             }
             .frame(height: headerHeight)

--- a/frontend/OnVoice/View/LibraryView.swift
+++ b/frontend/OnVoice/View/LibraryView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 struct LibraryView: View {
     @Binding var selectedTab: OnVoiceTab
     @State private var isShowingSituationRecognition = false
+    @State private var isShowingLibraryOptionsAlert = false
 
     var body: some View {
         NavigationStack {
@@ -16,9 +17,12 @@ struct LibraryView: View {
 
                 VStack(spacing: 0) {
                     HomeHeaderView(
-                        title: "\n라이브러리",
+                        title: "라이브러리",
                         showsProfileButton: true,
-                        showsTitleTrailingButton: true
+                        titleTopOffset: 32,
+                        onTitleTrailingButtonTap: {
+                            isShowingLibraryOptionsAlert = true
+                        }
                     )
 
                     VStack(alignment: .leading, spacing: 10) {
@@ -44,6 +48,11 @@ struct LibraryView: View {
             .toolbar(.hidden, for: .navigationBar)
             .navigationDestination(isPresented: $isShowingSituationRecognition) {
                 SituationRecognitionView()
+            }
+            .alert("준비 중", isPresented: $isShowingLibraryOptionsAlert) {
+                Button("확인", role: .cancel) {}
+            } message: {
+                Text("라이브러리 추가 옵션은 다음 단계에서 연결할 예정입니다.")
             }
         }
     }

--- a/frontend/OnVoice/View/LibraryView.swift
+++ b/frontend/OnVoice/View/LibraryView.swift
@@ -14,10 +14,11 @@ struct LibraryView: View {
             ZStack {
                 Color.bg.ignoresSafeArea()
 
-                VStack(alignment: .leading, spacing: 18) {
+                VStack(spacing: 0) {
                     HomeHeaderView(
-                        title: "라이브러리",
-                        showsProfileButton: false
+                        title: "\n라이브러리",
+                        showsProfileButton: true,
+                        showsTitleTrailingButton: true
                     )
 
                     VStack(alignment: .leading, spacing: 10) {
@@ -29,8 +30,8 @@ struct LibraryView: View {
                             .multilineTextAlignment(.leading)
                     }
                     .padding(.horizontal, 18)
-
-                    Spacer()
+                    .padding(.top, 18)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
                 }
             }
             .safeAreaInset(edge: .bottom, spacing: 0) {


### PR DESCRIPTION
## Summary
라이브러리 화면의 상단 헤더를 홈 화면과 동일한 기준으로 정렬했습니다.
좌상단 로고, 제목, 우상단 프로필 버튼 위치를 홈 화면과 맞췄고, 라이브러리 제목 우측에 `...` 버튼을 추가했습니다.

## Related Issue
- issue: #36  

## Changes (변경 사항)
- 라이브러리 헤더 레이아웃을 홈 화면과 동일한 구조로 정렬
- 좌상단 로고, 제목, 우상단 마이페이지 버튼 위치 조정
- 라이브러리 제목 우측에 `...` 버튼 추가
- `...` 버튼이 제목 아랫줄 높이에 맞춰 보이도록 배치
- 녹음 리스트 영역은 이번 PR 범위에서 제외

## Test
- [x] 로컬에서 테스트 완료
- [x] 기존 기능에 영향 없음

## Screenshots (Optional)
| 홈 화면 기준으로 정렬된 라이브러리 헤더 및 `...` 버튼 추가 |
|:--:|
| <img width="786" height="1708" alt="image" src="https://github.com/user-attachments/assets/4e3df262-9f1a-412d-889a-20f58f378883" /> |

## Checklist
- [x] 변경사항 400줄 이하
- [ ] 필요시 테스트 추가
- [ ] 필요시 문서 업데이트

## Additional Context (추가 사항)
- `...` 버튼은 UI만 추가한 상태이며, 기능은 아직 연결하지 않았습니다.
- 라이브러리의 녹음 리스트 UI는 추후 작업 예정입니다.