### PR TITLE
feat: 라이브러리 녹음 목록 및 날짜 구간 정렬 구현

### DIFF
--- a/frontend/OnVoice/Model/RecordingListOrganizer.swift
+++ b/frontend/OnVoice/Model/RecordingListOrganizer.swift
@@ -1,0 +1,140 @@
+//
+//  RecordingListOrganizer.swift
+//  OnVoice
+//
+
+import Foundation
+
+struct RecordingDisplayItem: Identifiable, Hashable {
+    let index: Int
+    let recording: Recording
+
+    var id: Recording.ID {
+        recording.id
+    }
+}
+
+struct RecordingLibrarySection: Identifiable, Hashable {
+    let id: String
+    let title: String
+    let items: [RecordingDisplayItem]
+}
+
+enum RecordingListOrganizer {
+    static var currentDate: () -> Date = Date.init
+
+    static func homeItems(
+        from recordings: [Recording],
+        calendar: Calendar = .current
+    ) -> [RecordingDisplayItem] {
+        let today = currentDate()
+        return sortedDisplayItems(from: recordings)
+            .filter { calendar.isDate($0.recording.createdAt, inSameDayAs: today) }
+    }
+
+    static func librarySections(
+        from recordings: [Recording],
+        calendar: Calendar = .current
+    ) -> [RecordingLibrarySection] {
+        let todayDate = currentDate()
+        let libraryItems = sortedDisplayItems(from: recordings)
+            .filter { !calendar.isDate($0.recording.createdAt, inSameDayAs: todayDate) }
+
+        guard !libraryItems.isEmpty else { return [] }
+
+        let today = calendar.startOfDay(for: todayDate)
+        var previous7Days: [RecordingDisplayItem] = []
+        var previous30Days: [RecordingDisplayItem] = []
+        var monthlyBuckets: [Date: [RecordingDisplayItem]] = [:]
+
+        for item in libraryItems {
+            let recordingDay = calendar.startOfDay(for: item.recording.createdAt)
+            let dayOffset = calendar.dateComponents([.day], from: recordingDay, to: today).day ?? 0
+
+            switch dayOffset {
+            case 1...7:
+                previous7Days.append(item)
+            case 8...30:
+                previous30Days.append(item)
+            default:
+                let monthStart = calendar.dateInterval(of: .month, for: item.recording.createdAt)?.start ?? recordingDay
+                monthlyBuckets[monthStart, default: []].append(item)
+            }
+        }
+
+        var sections: [RecordingLibrarySection] = []
+
+        if !previous7Days.isEmpty {
+            sections.append(
+                RecordingLibrarySection(
+                    id: "previous-7-days",
+                    title: "이전 7일",
+                    items: previous7Days
+                )
+            )
+        }
+
+        if !previous30Days.isEmpty {
+            sections.append(
+                RecordingLibrarySection(
+                    id: "previous-30-days",
+                    title: "이전 30일",
+                    items: previous30Days
+                )
+            )
+        }
+
+        let sortedMonthStarts = monthlyBuckets.keys.sorted(by: >)
+        for monthStart in sortedMonthStarts {
+            guard let items = monthlyBuckets[monthStart] else { continue }
+
+            sections.append(
+                RecordingLibrarySection(
+                    id: monthSectionID(for: monthStart, calendar: calendar),
+                    title: monthSectionTitle(for: monthStart, calendar: calendar),
+                    items: items
+                )
+            )
+        }
+
+        return sections
+    }
+
+    static func displayTitle(for item: RecordingDisplayItem) -> String {
+        if item.recording.usesGeneratedDefaultTitle {
+            return "새로운 대화 기록 (\(item.index))"
+        }
+
+        return item.recording.title
+    }
+
+    private static func sortedDisplayItems(from recordings: [Recording]) -> [RecordingDisplayItem] {
+        let sortedRecordings = recordings.sorted { lhs, rhs in
+            lhs.createdAt > rhs.createdAt
+        }
+
+        return sortedRecordings.enumerated().map { offset, recording in
+            RecordingDisplayItem(
+                index: sortedRecordings.count - offset,
+                recording: recording
+            )
+        }
+    }
+
+    private static func monthSectionID(for date: Date, calendar: Calendar) -> String {
+        let components = calendar.dateComponents([.year, .month], from: date)
+        return "month-\(components.year ?? 0)-\(components.month ?? 0)"
+    }
+
+    private static func monthSectionTitle(for date: Date, calendar: Calendar) -> String {
+        let currentYear = calendar.component(.year, from: currentDate())
+        let year = calendar.component(.year, from: date)
+        let month = calendar.component(.month, from: date)
+
+        if year == currentYear {
+            return "\(month)월"
+        }
+
+        return "\(year)년 \(month)월"
+    }
+}

--- a/frontend/OnVoice/Model/RecordingListOrganizer.swift
+++ b/frontend/OnVoice/Model/RecordingListOrganizer.swift
@@ -43,18 +43,19 @@ enum RecordingListOrganizer {
         guard !libraryItems.isEmpty else { return [] }
 
         let today = calendar.startOfDay(for: todayDate)
+        let previous7DaysStart = calendar.date(byAdding: .day, value: -7, to: today) ?? today
+        let previous30DaysStart = calendar.date(byAdding: .day, value: -30, to: today) ?? today
         var previous7Days: [RecordingDisplayItem] = []
         var previous30Days: [RecordingDisplayItem] = []
         var monthlyBuckets: [Date: [RecordingDisplayItem]] = [:]
 
         for item in libraryItems {
             let recordingDay = calendar.startOfDay(for: item.recording.createdAt)
-            let dayOffset = calendar.dateComponents([.day], from: recordingDay, to: today).day ?? 0
 
-            switch dayOffset {
-            case 1...7:
+            switch recordingDay {
+            case previous7DaysStart..<today:
                 previous7Days.append(item)
-            case 8...30:
+            case previous30DaysStart..<previous7DaysStart:
                 previous30Days.append(item)
             default:
                 let monthStart = calendar.dateInterval(of: .month, for: item.recording.createdAt)?.start ?? recordingDay
@@ -69,7 +70,7 @@ enum RecordingListOrganizer {
                 RecordingLibrarySection(
                     id: "previous-7-days",
                     title: "이전 7일",
-                    items: previous7Days
+                    items: sortedSectionItems(previous7Days)
                 )
             )
         }
@@ -79,7 +80,7 @@ enum RecordingListOrganizer {
                 RecordingLibrarySection(
                     id: "previous-30-days",
                     title: "이전 30일",
-                    items: previous30Days
+                    items: sortedSectionItems(previous30Days)
                 )
             )
         }
@@ -92,7 +93,7 @@ enum RecordingListOrganizer {
                 RecordingLibrarySection(
                     id: monthSectionID(for: monthStart, calendar: calendar),
                     title: monthSectionTitle(for: monthStart, calendar: calendar),
-                    items: items
+                    items: sortedSectionItems(items)
                 )
             )
         }
@@ -118,6 +119,12 @@ enum RecordingListOrganizer {
                 index: sortedRecordings.count - offset,
                 recording: recording
             )
+        }
+    }
+
+    private static func sortedSectionItems(_ items: [RecordingDisplayItem]) -> [RecordingDisplayItem] {
+        items.sorted { lhs, rhs in
+            lhs.recording.createdAt > rhs.recording.createdAt
         }
     }
 

--- a/frontend/OnVoice/Model/RecordingListOrganizer.swift
+++ b/frontend/OnVoice/Model/RecordingListOrganizer.swift
@@ -21,7 +21,14 @@ struct RecordingLibrarySection: Identifiable, Hashable {
 }
 
 enum RecordingListOrganizer {
-    static var currentDate: () -> Date = Date.init
+    private enum SectionID: String {
+        case previous7Days = "previous-7-days"
+        case previous30Days = "previous-30-days"
+    }
+
+    // Relative-date sections use calendar-day boundaries, not rolling 24-hour windows.
+    private static let previous7DaysWindow = 7
+    private static let previous30DaysWindow = 30
 
     private enum RelativeSection {
         case today
@@ -32,12 +39,12 @@ enum RecordingListOrganizer {
 
     static func homeItems(
         from recordings: [Recording],
-        calendar: Calendar = .current
+        calendar: Calendar = .current,
+        now: Date = Date()
     ) -> [RecordingDisplayItem] {
-        let today = currentDate()
         return sortedDisplayItems(from: recordings)
             .filter {
-                if case .today = relativeSection(for: $0.recording.createdAt, comparedTo: today, calendar: calendar) {
+                if case .today = relativeSection(for: $0.recording.createdAt, comparedTo: now, calendar: calendar) {
                     return true
                 }
 
@@ -47,11 +54,11 @@ enum RecordingListOrganizer {
 
     static func librarySections(
         from recordings: [Recording],
-        calendar: Calendar = .current
+        calendar: Calendar = .current,
+        now: Date = Date()
     ) -> [RecordingLibrarySection] {
-        let todayDate = currentDate()
         let libraryItems = sortedDisplayItems(from: recordings)
-            .filter { !calendar.isDate($0.recording.createdAt, inSameDayAs: todayDate) }
+            .filter { !calendar.isDate($0.recording.createdAt, inSameDayAs: now) }
 
         guard !libraryItems.isEmpty else { return [] }
 
@@ -60,7 +67,7 @@ enum RecordingListOrganizer {
         var monthlyBuckets: [Date: [RecordingDisplayItem]] = [:]
 
         for item in libraryItems {
-            switch relativeSection(for: item.recording.createdAt, comparedTo: todayDate, calendar: calendar) {
+            switch relativeSection(for: item.recording.createdAt, comparedTo: now, calendar: calendar) {
             case .today:
                 continue
             case .previous7Days:
@@ -77,7 +84,7 @@ enum RecordingListOrganizer {
         if !previous7Days.isEmpty {
             sections.append(
                 RecordingLibrarySection(
-                    id: "previous-7-days",
+                    id: SectionID.previous7Days.rawValue,
                     title: "이전 7일",
                     items: sortedSectionItems(previous7Days)
                 )
@@ -87,7 +94,7 @@ enum RecordingListOrganizer {
         if !previous30Days.isEmpty {
             sections.append(
                 RecordingLibrarySection(
-                    id: "previous-30-days",
+                    id: SectionID.previous30Days.rawValue,
                     title: "이전 30일",
                     items: sortedSectionItems(previous30Days)
                 )
@@ -101,7 +108,7 @@ enum RecordingListOrganizer {
             sections.append(
                 RecordingLibrarySection(
                     id: monthSectionID(for: monthStart, calendar: calendar),
-                    title: monthSectionTitle(for: monthStart, calendar: calendar),
+                    title: monthSectionTitle(for: monthStart, comparedTo: now, calendar: calendar),
                     items: sortedSectionItems(items)
                 )
             )
@@ -149,12 +156,20 @@ enum RecordingListOrganizer {
             return .today
         }
 
-        let previous7DaysStart = calendar.date(byAdding: .day, value: -7, to: referenceDay) ?? referenceDay
+        let previous7DaysStart = calendar.date(
+            byAdding: .day,
+            value: -previous7DaysWindow,
+            to: referenceDay
+        ) ?? referenceDay
         if previous7DaysStart <= targetDay && targetDay < referenceDay {
             return .previous7Days
         }
 
-        let previous30DaysStart = calendar.date(byAdding: .day, value: -30, to: referenceDay) ?? referenceDay
+        let previous30DaysStart = calendar.date(
+            byAdding: .day,
+            value: -previous30DaysWindow,
+            to: referenceDay
+        ) ?? referenceDay
         if previous30DaysStart <= targetDay && targetDay < previous7DaysStart {
             return .previous30Days
         }
@@ -168,8 +183,8 @@ enum RecordingListOrganizer {
         return "month-\(components.year ?? 0)-\(components.month ?? 0)"
     }
 
-    private static func monthSectionTitle(for date: Date, calendar: Calendar) -> String {
-        let currentYear = calendar.component(.year, from: currentDate())
+    private static func monthSectionTitle(for date: Date, comparedTo referenceDate: Date, calendar: Calendar) -> String {
+        let currentYear = calendar.component(.year, from: referenceDate)
         let year = calendar.component(.year, from: date)
         let month = calendar.component(.month, from: date)
 

--- a/frontend/OnVoice/Model/RecordingListOrganizer.swift
+++ b/frontend/OnVoice/Model/RecordingListOrganizer.swift
@@ -23,13 +23,26 @@ struct RecordingLibrarySection: Identifiable, Hashable {
 enum RecordingListOrganizer {
     static var currentDate: () -> Date = Date.init
 
+    private enum RelativeSection {
+        case today
+        case previous7Days
+        case previous30Days
+        case monthly(Date)
+    }
+
     static func homeItems(
         from recordings: [Recording],
         calendar: Calendar = .current
     ) -> [RecordingDisplayItem] {
         let today = currentDate()
         return sortedDisplayItems(from: recordings)
-            .filter { calendar.isDate($0.recording.createdAt, inSameDayAs: today) }
+            .filter {
+                if case .today = relativeSection(for: $0.recording.createdAt, comparedTo: today, calendar: calendar) {
+                    return true
+                }
+
+                return false
+            }
     }
 
     static func librarySections(
@@ -42,23 +55,19 @@ enum RecordingListOrganizer {
 
         guard !libraryItems.isEmpty else { return [] }
 
-        let today = calendar.startOfDay(for: todayDate)
-        let previous7DaysStart = calendar.date(byAdding: .day, value: -7, to: today) ?? today
-        let previous30DaysStart = calendar.date(byAdding: .day, value: -30, to: today) ?? today
         var previous7Days: [RecordingDisplayItem] = []
         var previous30Days: [RecordingDisplayItem] = []
         var monthlyBuckets: [Date: [RecordingDisplayItem]] = [:]
 
         for item in libraryItems {
-            let recordingDay = calendar.startOfDay(for: item.recording.createdAt)
-
-            switch recordingDay {
-            case previous7DaysStart..<today:
+            switch relativeSection(for: item.recording.createdAt, comparedTo: todayDate, calendar: calendar) {
+            case .today:
+                continue
+            case .previous7Days:
                 previous7Days.append(item)
-            case previous30DaysStart..<previous7DaysStart:
+            case .previous30Days:
                 previous30Days.append(item)
-            default:
-                let monthStart = calendar.dateInterval(of: .month, for: item.recording.createdAt)?.start ?? recordingDay
+            case let .monthly(monthStart):
                 monthlyBuckets[monthStart, default: []].append(item)
             }
         }
@@ -126,6 +135,32 @@ enum RecordingListOrganizer {
         items.sorted { lhs, rhs in
             lhs.recording.createdAt > rhs.recording.createdAt
         }
+    }
+
+    private static func relativeSection(
+        for date: Date,
+        comparedTo referenceDate: Date,
+        calendar: Calendar
+    ) -> RelativeSection {
+        let referenceDay = calendar.startOfDay(for: referenceDate)
+        let targetDay = calendar.startOfDay(for: date)
+
+        if targetDay == referenceDay {
+            return .today
+        }
+
+        let previous7DaysStart = calendar.date(byAdding: .day, value: -7, to: referenceDay) ?? referenceDay
+        if previous7DaysStart <= targetDay && targetDay < referenceDay {
+            return .previous7Days
+        }
+
+        let previous30DaysStart = calendar.date(byAdding: .day, value: -30, to: referenceDay) ?? referenceDay
+        if previous30DaysStart <= targetDay && targetDay < previous7DaysStart {
+            return .previous30Days
+        }
+
+        let monthStart = calendar.dateInterval(of: .month, for: targetDay)?.start ?? targetDay
+        return .monthly(monthStart)
     }
 
     private static func monthSectionID(for date: Date, calendar: Calendar) -> String {

--- a/frontend/OnVoice/Service/AudioRecord.swift
+++ b/frontend/OnVoice/Service/AudioRecord.swift
@@ -128,6 +128,11 @@ class AudioRecorder: ObservableObject {
             throw RecordingMutationError.recordingNotFound
         }
 
+        let currentNormalizedTitle = Self.sanitizedRecordingTitle(from: recording.title)
+        if sanitizedTitle == currentNormalizedTitle {
+            return recording
+        }
+
         let destinationURL = uniqueRecordingURL(for: recording, sanitizedTitle: sanitizedTitle)
         guard destinationURL != recording.fileURL else { return recording }
 

--- a/frontend/OnVoice/View/HomeView.swift
+++ b/frontend/OnVoice/View/HomeView.swift
@@ -20,10 +20,8 @@ struct HomeView: View {
     @State private var deletePromptTitle = ""
     @State private var mutationErrorMessage = ""
 
-    private var displayedRecordings: [(index: Int, recording: Recording)] {
-        Array(recorder.recordings.reversed().enumerated()).map { offset, recording in
-            (recorder.recordings.count - offset, recording)
-        }
+    private var displayedRecordings: [RecordingDisplayItem] {
+        RecordingListOrganizer.homeItems(from: recorder.recordings)
     }
 
     var body: some View {
@@ -55,8 +53,8 @@ struct HomeView: View {
                             } else {
                                 ScrollView(showsIndicators: false) {
                                     VStack(spacing: 16) {
-                                        ForEach(displayedRecordings, id: \.recording.id) { item in
-                                            let displayTitle = title(for: item.recording, index: item.index)
+                                        ForEach(displayedRecordings) { item in
+                                            let displayTitle = RecordingListOrganizer.displayTitle(for: item)
                                             RecordingRowView(
                                                 id: item.recording.id,
                                                 title: displayTitle,
@@ -246,14 +244,6 @@ struct HomeView: View {
 
     private func presentMutationError(_ error: Error) {
         mutationErrorMessage = error.localizedDescription
-    }
-
-    private func title(for recording: Recording, index: Int) -> String {
-        if recording.usesGeneratedDefaultTitle {
-            return "새로운 대화 기록 (\(index))"
-        }
-
-        return recording.title
     }
 
     private func todayDateString() -> String {

--- a/frontend/OnVoice/View/HomeView.swift
+++ b/frontend/OnVoice/View/HomeView.swift
@@ -209,8 +209,12 @@ struct HomeView: View {
     private func commitRename() {
         guard let recordingToRename else { return }
 
-        if recordingToRename.usesGeneratedDefaultTitle,
-           pendingRecordingTitle == originalPendingRecordingTitle {
+        let sanitizedPendingTitle = AudioRecorder.sanitizedRecordingTitle(from: pendingRecordingTitle)
+        let sanitizedCurrentTitle = AudioRecorder.sanitizedRecordingTitle(from: recordingToRename.title)
+        let sanitizedOriginalDisplayTitle = AudioRecorder.sanitizedRecordingTitle(from: originalPendingRecordingTitle)
+
+        if sanitizedPendingTitle == sanitizedCurrentTitle ||
+            (recordingToRename.usesGeneratedDefaultTitle && sanitizedPendingTitle == sanitizedOriginalDisplayTitle) {
             clearRenameState()
             return
         }

--- a/frontend/OnVoice/View/HomeView.swift
+++ b/frontend/OnVoice/View/HomeView.swift
@@ -208,8 +208,6 @@ struct HomeView: View {
 
     private func commitRename() {
         guard let recordingToRename else { return }
-        let sanitizedPendingTitle = AudioRecorder.sanitizedRecordingTitle(from: pendingRecordingTitle)
-        let normalizedCurrentTitle = AudioRecorder.sanitizedRecordingTitle(from: recordingToRename.title)
 
         if recordingToRename.usesGeneratedDefaultTitle,
            pendingRecordingTitle == originalPendingRecordingTitle {
@@ -217,19 +215,8 @@ struct HomeView: View {
             return
         }
 
-        if sanitizedPendingTitle.isEmpty {
-            clearRenameState()
-            presentMutationError(AudioRecorder.RecordingMutationError.invalidTitle)
-            return
-        }
-
-        if sanitizedPendingTitle == normalizedCurrentTitle {
-            clearRenameState()
-            return
-        }
-
         do {
-            let updatedRecording = try recorder.renameRecording(recordingToRename, to: sanitizedPendingTitle)
+            let updatedRecording = try recorder.renameRecording(recordingToRename, to: pendingRecordingTitle)
             if selectedRecording?.id == recordingToRename.id {
                 selectedRecording = updatedRecording
             }

--- a/frontend/OnVoice/View/HomeView.swift
+++ b/frontend/OnVoice/View/HomeView.swift
@@ -209,6 +209,7 @@ struct HomeView: View {
     private func commitRename() {
         guard let recordingToRename else { return }
         let sanitizedPendingTitle = AudioRecorder.sanitizedRecordingTitle(from: pendingRecordingTitle)
+        let normalizedCurrentTitle = AudioRecorder.sanitizedRecordingTitle(from: recordingToRename.title)
 
         if recordingToRename.usesGeneratedDefaultTitle,
            pendingRecordingTitle == originalPendingRecordingTitle {
@@ -222,7 +223,7 @@ struct HomeView: View {
             return
         }
 
-        if sanitizedPendingTitle == recordingToRename.title {
+        if sanitizedPendingTitle == normalizedCurrentTitle {
             clearRenameState()
             return
         }

--- a/frontend/OnVoice/View/HomeView.swift
+++ b/frontend/OnVoice/View/HomeView.swift
@@ -208,6 +208,7 @@ struct HomeView: View {
 
     private func commitRename() {
         guard let recordingToRename else { return }
+        let sanitizedPendingTitle = AudioRecorder.sanitizedRecordingTitle(from: pendingRecordingTitle)
 
         if recordingToRename.usesGeneratedDefaultTitle,
            pendingRecordingTitle == originalPendingRecordingTitle {
@@ -215,8 +216,19 @@ struct HomeView: View {
             return
         }
 
+        if sanitizedPendingTitle.isEmpty {
+            clearRenameState()
+            presentMutationError(AudioRecorder.RecordingMutationError.invalidTitle)
+            return
+        }
+
+        if sanitizedPendingTitle == recordingToRename.title {
+            clearRenameState()
+            return
+        }
+
         do {
-            let updatedRecording = try recorder.renameRecording(recordingToRename, to: pendingRecordingTitle)
+            let updatedRecording = try recorder.renameRecording(recordingToRename, to: sanitizedPendingTitle)
             if selectedRecording?.id == recordingToRename.id {
                 selectedRecording = updatedRecording
             }

--- a/frontend/OnVoice/View/LibraryView.swift
+++ b/frontend/OnVoice/View/LibraryView.swift
@@ -6,9 +6,22 @@
 import SwiftUI
 
 struct LibraryView: View {
+    @EnvironmentObject var recorder: AudioRecorder
     @Binding var selectedTab: OnVoiceTab
     @State private var isShowingSituationRecognition = false
     @State private var isShowingLibraryOptionsAlert = false
+    @State private var selectedRecording: Recording?
+    @State private var openedRowID: Recording.ID?
+    @State private var recordingToRename: Recording?
+    @State private var originalPendingRecordingTitle = ""
+    @State private var pendingRecordingTitle = ""
+    @State private var recordingToDelete: Recording?
+    @State private var deletePromptTitle = ""
+    @State private var mutationErrorMessage = ""
+
+    private var sections: [RecordingLibrarySection] {
+        RecordingListOrganizer.librarySections(from: recorder.recordings)
+    }
 
     var body: some View {
         NavigationStack {
@@ -25,19 +38,14 @@ struct LibraryView: View {
                         }
                     )
 
-                    VStack(alignment: .leading, spacing: 10) {
-                        Text("준비 중")
-                            .onVoiceTextStyle(.title2, color: .gray1)
-
-                        Text("라이브러리 화면은 다음 단계에서 연결할 수 있도록 자리만 먼저 잡아두었습니다.")
-                            .onVoiceTextStyle(.body5, color: .gray4)
-                            .multilineTextAlignment(.leading)
-                    }
-                    .padding(.horizontal, 18)
-                    .padding(.top, 18)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                    libraryContent
                 }
             }
+            .simultaneousGesture(
+                TapGesture().onEnded {
+                    closeOpenedRowIfNeeded()
+                }
+            )
             .safeAreaInset(edge: .bottom, spacing: 0) {
                 BottomDockView(
                     selectedTab: $selectedTab,
@@ -49,15 +57,239 @@ struct LibraryView: View {
             .navigationDestination(isPresented: $isShowingSituationRecognition) {
                 SituationRecognitionView()
             }
+            .navigationDestination(item: $selectedRecording) { recording in
+                AnalysisSummaryView(recording: recording)
+            }
+            .onChange(of: selectedTab) { _ in
+                closeOpenedRowIfNeeded()
+            }
+            .onChange(of: isShowingSituationRecognition) { isPresented in
+                if isPresented {
+                    closeOpenedRowIfNeeded()
+                }
+            }
+            .onChange(of: selectedRecording) { _ in
+                closeOpenedRowIfNeeded()
+            }
             .alert("준비 중", isPresented: $isShowingLibraryOptionsAlert) {
                 Button("확인", role: .cancel) {}
             } message: {
                 Text("라이브러리 추가 옵션은 다음 단계에서 연결할 예정입니다.")
             }
+            .alert("녹음 이름 수정", isPresented: renameAlertIsPresented) {
+                TextField("녹음 이름", text: $pendingRecordingTitle)
+
+                Button("취소", role: .cancel) {
+                    clearRenameState()
+                }
+
+                Button("저장") {
+                    commitRename()
+                }
+            } message: {
+                Text("녹음 파일 이름을 바꾸면 라이브러리 리스트 제목도 함께 변경됩니다.")
+            }
+            .alert("녹음 삭제", isPresented: deleteAlertIsPresented, presenting: recordingToDelete) { recording in
+                Button("취소", role: .cancel) {
+                    recordingToDelete = nil
+                    deletePromptTitle = ""
+                }
+
+                Button("삭제", role: .destructive) {
+                    commitDelete(recording)
+                }
+            } message: { _ in
+                Text("'\(deletePromptTitle)' 녹음을 삭제할까요?")
+            }
+            .alert("작업 실패", isPresented: mutationErrorIsPresented) {
+                Button("확인", role: .cancel) {
+                    mutationErrorMessage = ""
+                }
+            } message: {
+                Text(mutationErrorMessage)
+            }
         }
+    }
+
+    private var libraryContent: some View {
+        Group {
+            if sections.isEmpty {
+                emptyLibraryContent
+            } else {
+                recordingsLibraryContent
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private var emptyLibraryContent: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("기록")
+                .onVoiceTextStyle(.body2, color: .sub)
+                .padding(.top, 18)
+                .hidden()
+
+            GeometryReader { proxy in
+                ScrollView(showsIndicators: false) {
+                    EmptyRecordView()
+                        .frame(maxWidth: .infinity)
+                        .padding(.top, 88)
+                        .padding(.bottom, 132)
+                        .frame(minHeight: proxy.size.height, alignment: .top)
+                }
+                .scrollBounceBehavior(.basedOnSize)
+                .padding(.top, 18)
+            }
+        }
+        .padding(.horizontal, 18)
+    }
+
+    private var recordingsLibraryContent: some View {
+        ScrollView(showsIndicators: false) {
+            VStack(alignment: .leading, spacing: 26) {
+                ForEach(sections) { section in
+                    librarySection(section)
+                }
+            }
+            .padding(.top, 18)
+            .padding(.bottom, 132)
+        }
+        .padding(.horizontal, 18)
+    }
+
+    private func librarySection(_ section: RecordingLibrarySection) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text(section.title)
+                .onVoiceTextStyle(.title2, color: .gray1)
+
+            VStack(spacing: 16) {
+                ForEach(section.items) { item in
+                    libraryRow(item)
+                }
+            }
+        }
+    }
+
+    private func libraryRow(_ item: RecordingDisplayItem) -> some View {
+        let displayTitle = RecordingListOrganizer.displayTitle(for: item)
+
+        return RecordingRowView(
+            id: item.recording.id,
+            title: displayTitle,
+            subtitle: "\(item.recording.formattedDate) • \(item.recording.formattedDuration)",
+            openedRowID: $openedRowID,
+            onTap: {
+                selectedRecording = item.recording
+            },
+            onEdit: {
+                beginRenaming(item.recording, suggestedTitle: displayTitle)
+            },
+            onDelete: {
+                clearRenameState()
+                recordingToDelete = item.recording
+                deletePromptTitle = displayTitle
+            }
+        )
+    }
+
+    private func closeOpenedRowIfNeeded() {
+        guard openedRowID != nil else { return }
+
+        withAnimation(RecordingRowSwipeBehavior.snapAnimation) {
+            openedRowID = nil
+        }
+    }
+
+    private var renameAlertIsPresented: Binding<Bool> {
+        Binding(
+            get: { recordingToRename != nil },
+            set: { isPresented in
+                if !isPresented {
+                    clearRenameState()
+                }
+            }
+        )
+    }
+
+    private var deleteAlertIsPresented: Binding<Bool> {
+        Binding(
+            get: { recordingToDelete != nil },
+            set: { isPresented in
+                if !isPresented {
+                    recordingToDelete = nil
+                    deletePromptTitle = ""
+                }
+            }
+        )
+    }
+
+    private var mutationErrorIsPresented: Binding<Bool> {
+        Binding(
+            get: { !mutationErrorMessage.isEmpty },
+            set: { isPresented in
+                if !isPresented {
+                    mutationErrorMessage = ""
+                }
+            }
+        )
+    }
+
+    private func beginRenaming(_ recording: Recording, suggestedTitle: String) {
+        recordingToDelete = nil
+        deletePromptTitle = ""
+        recordingToRename = recording
+        originalPendingRecordingTitle = suggestedTitle
+        pendingRecordingTitle = suggestedTitle
+    }
+
+    private func clearRenameState() {
+        recordingToRename = nil
+        originalPendingRecordingTitle = ""
+        pendingRecordingTitle = ""
+    }
+
+    private func commitRename() {
+        guard let recordingToRename else { return }
+
+        if recordingToRename.usesGeneratedDefaultTitle,
+           pendingRecordingTitle == originalPendingRecordingTitle {
+            clearRenameState()
+            return
+        }
+
+        do {
+            let updatedRecording = try recorder.renameRecording(recordingToRename, to: pendingRecordingTitle)
+            if selectedRecording?.id == recordingToRename.id {
+                selectedRecording = updatedRecording
+            }
+            clearRenameState()
+        } catch {
+            clearRenameState()
+            presentMutationError(error)
+        }
+    }
+
+    private func commitDelete(_ recording: Recording) {
+        do {
+            try recorder.deleteRecording(recording)
+            if selectedRecording?.id == recording.id {
+                selectedRecording = nil
+            }
+            recordingToDelete = nil
+            deletePromptTitle = ""
+        } catch {
+            recordingToDelete = nil
+            deletePromptTitle = ""
+            presentMutationError(error)
+        }
+    }
+
+    private func presentMutationError(_ error: Error) {
+        mutationErrorMessage = error.localizedDescription
     }
 }
 
 #Preview {
     LibraryView(selectedTab: .constant(.library))
+        .environmentObject(AudioRecorder())
 }

--- a/frontend/OnVoice/View/LibraryView.swift
+++ b/frontend/OnVoice/View/LibraryView.swift
@@ -250,8 +250,6 @@ struct LibraryView: View {
 
     private func commitRename() {
         guard let recordingToRename else { return }
-        let sanitizedPendingTitle = AudioRecorder.sanitizedRecordingTitle(from: pendingRecordingTitle)
-        let normalizedCurrentTitle = AudioRecorder.sanitizedRecordingTitle(from: recordingToRename.title)
 
         if recordingToRename.usesGeneratedDefaultTitle,
            pendingRecordingTitle == originalPendingRecordingTitle {
@@ -259,19 +257,8 @@ struct LibraryView: View {
             return
         }
 
-        if sanitizedPendingTitle.isEmpty {
-            clearRenameState()
-            presentMutationError(AudioRecorder.RecordingMutationError.invalidTitle)
-            return
-        }
-
-        if sanitizedPendingTitle == normalizedCurrentTitle {
-            clearRenameState()
-            return
-        }
-
         do {
-            let updatedRecording = try recorder.renameRecording(recordingToRename, to: sanitizedPendingTitle)
+            let updatedRecording = try recorder.renameRecording(recordingToRename, to: pendingRecordingTitle)
             if selectedRecording?.id == recordingToRename.id {
                 selectedRecording = updatedRecording
             }

--- a/frontend/OnVoice/View/LibraryView.swift
+++ b/frontend/OnVoice/View/LibraryView.swift
@@ -251,6 +251,7 @@ struct LibraryView: View {
     private func commitRename() {
         guard let recordingToRename else { return }
         let sanitizedPendingTitle = AudioRecorder.sanitizedRecordingTitle(from: pendingRecordingTitle)
+        let normalizedCurrentTitle = AudioRecorder.sanitizedRecordingTitle(from: recordingToRename.title)
 
         if recordingToRename.usesGeneratedDefaultTitle,
            pendingRecordingTitle == originalPendingRecordingTitle {
@@ -264,7 +265,7 @@ struct LibraryView: View {
             return
         }
 
-        if sanitizedPendingTitle == recordingToRename.title {
+        if sanitizedPendingTitle == normalizedCurrentTitle {
             clearRenameState()
             return
         }

--- a/frontend/OnVoice/View/LibraryView.swift
+++ b/frontend/OnVoice/View/LibraryView.swift
@@ -250,6 +250,7 @@ struct LibraryView: View {
 
     private func commitRename() {
         guard let recordingToRename else { return }
+        let sanitizedPendingTitle = AudioRecorder.sanitizedRecordingTitle(from: pendingRecordingTitle)
 
         if recordingToRename.usesGeneratedDefaultTitle,
            pendingRecordingTitle == originalPendingRecordingTitle {
@@ -257,8 +258,19 @@ struct LibraryView: View {
             return
         }
 
+        if sanitizedPendingTitle.isEmpty {
+            clearRenameState()
+            presentMutationError(AudioRecorder.RecordingMutationError.invalidTitle)
+            return
+        }
+
+        if sanitizedPendingTitle == recordingToRename.title {
+            clearRenameState()
+            return
+        }
+
         do {
-            let updatedRecording = try recorder.renameRecording(recordingToRename, to: pendingRecordingTitle)
+            let updatedRecording = try recorder.renameRecording(recordingToRename, to: sanitizedPendingTitle)
             if selectedRecording?.id == recordingToRename.id {
                 selectedRecording = updatedRecording
             }

--- a/frontend/OnVoice/View/LibraryView.swift
+++ b/frontend/OnVoice/View/LibraryView.swift
@@ -251,8 +251,12 @@ struct LibraryView: View {
     private func commitRename() {
         guard let recordingToRename else { return }
 
-        if recordingToRename.usesGeneratedDefaultTitle,
-           pendingRecordingTitle == originalPendingRecordingTitle {
+        let sanitizedPendingTitle = AudioRecorder.sanitizedRecordingTitle(from: pendingRecordingTitle)
+        let sanitizedCurrentTitle = AudioRecorder.sanitizedRecordingTitle(from: recordingToRename.title)
+        let sanitizedOriginalDisplayTitle = AudioRecorder.sanitizedRecordingTitle(from: originalPendingRecordingTitle)
+
+        if sanitizedPendingTitle == sanitizedCurrentTitle ||
+            (recordingToRename.usesGeneratedDefaultTitle && sanitizedPendingTitle == sanitizedOriginalDisplayTitle) {
             clearRenameState()
             return
         }

--- a/frontend/OnVoiceTests/AudioRecorderMutationTests.swift
+++ b/frontend/OnVoiceTests/AudioRecorderMutationTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+@testable import OnVoice
+
+final class AudioRecorderMutationTests: XCTestCase {
+    private var tempDirectoryURL: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDirectoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDirectoryURL, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempDirectoryURL, FileManager.default.fileExists(atPath: tempDirectoryURL.path) {
+            try FileManager.default.removeItem(at: tempDirectoryURL)
+        }
+        tempDirectoryURL = nil
+        try super.tearDownWithError()
+    }
+
+    func testRenameRecordingRejectsBlankTitle() throws {
+        let recorder = AudioRecorder()
+        let recording = try makeRecording(named: "기존 제목")
+        recorder.recordings = [recording]
+
+        XCTAssertThrowsError(try recorder.renameRecording(recording, to: "   \n  ")) { error in
+            guard case AudioRecorder.RecordingMutationError.invalidTitle = error else {
+                return XCTFail("Expected invalidTitle, got \(error)")
+            }
+        }
+    }
+
+    func testRenameRecordingReturnsOriginalWhenSanitizedTitleMatchesCurrentTitle() throws {
+        let recorder = AudioRecorder()
+        let recording = try makeRecording(named: "회의 메모")
+        recorder.recordings = [recording]
+
+        let updatedRecording = try recorder.renameRecording(recording, to: "  회의 메모  ")
+
+        XCTAssertEqual(updatedRecording, recording)
+        XCTAssertEqual(recorder.recordings, [recording])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: recording.fileURL.path))
+    }
+
+    func testRenameRecordingMovesFileAndUpdatesPublishedRecordings() throws {
+        let recorder = AudioRecorder()
+        let recording = try makeRecording(named: "기존 제목")
+        recorder.recordings = [recording]
+
+        let updatedRecording = try recorder.renameRecording(recording, to: "  새 제목  ")
+
+        XCTAssertEqual(updatedRecording.title, "새 제목")
+        XCTAssertEqual(recorder.recordings, [updatedRecording])
+        XCTAssertFalse(FileManager.default.fileExists(atPath: recording.fileURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: updatedRecording.fileURL.path))
+    }
+
+    func testDeleteRecordingRemovesFileAndRecording() throws {
+        let recorder = AudioRecorder()
+        let recording = try makeRecording(named: "삭제 대상")
+        recorder.recordings = [recording]
+
+        try recorder.deleteRecording(recording)
+
+        XCTAssertTrue(recorder.recordings.isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: recording.fileURL.path))
+    }
+
+    private func makeRecording(named name: String) throws -> Recording {
+        let fileURL = tempDirectoryURL
+            .appendingPathComponent(name)
+            .appendingPathExtension("m4a")
+        let created = FileManager.default.createFile(atPath: fileURL.path, contents: Data())
+        XCTAssertTrue(created)
+
+        return Recording(
+            fileURL: fileURL,
+            createdAt: Date(timeIntervalSince1970: 0),
+            duration: 42
+        )
+    }
+}

--- a/frontend/OnVoiceTests/RecordingRowSwipeBehaviorTests.swift
+++ b/frontend/OnVoiceTests/RecordingRowSwipeBehaviorTests.swift
@@ -231,6 +231,34 @@ final class RecordingRowSwipeBehaviorTests: XCTestCase {
         XCTAssertEqual(librarySections.map(\.title), ["2월", "2025년 12월"])
     }
 
+    func testHomeAndLibraryUseSameDayBoundaryConsistently() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "Asia/Seoul")!
+
+        let now = calendar.date(from: DateComponents(year: 2026, month: 4, day: 14, hour: 0, minute: 30))!
+        let justAfterMidnight = makeRecording(
+            named: "Recording_20260414_001000",
+            createdAt: calendar.date(from: DateComponents(year: 2026, month: 4, day: 14, hour: 0, minute: 10))!
+        )
+        let previousLateNight = makeRecording(
+            named: "Recording_20260413_235000",
+            createdAt: calendar.date(from: DateComponents(year: 2026, month: 4, day: 13, hour: 23, minute: 50))!
+        )
+
+        let recordings = [previousLateNight, justAfterMidnight]
+
+        let homeItems = withFixedCurrentDate(now) {
+            RecordingListOrganizer.homeItems(from: recordings, calendar: calendar)
+        }
+        let librarySections = withFixedCurrentDate(now) {
+            RecordingListOrganizer.librarySections(from: recordings, calendar: calendar)
+        }
+
+        XCTAssertEqual(homeItems.map(\.recording.id), [justAfterMidnight.id])
+        XCTAssertEqual(librarySections.map(\.title), ["이전 7일"])
+        XCTAssertEqual(librarySections[0].items.map(\.recording.id), [previousLateNight.id])
+    }
+
     private func makeRecording(named name: String, createdAt: Date) -> Recording {
         Recording(
             fileURL: URL(fileURLWithPath: "/tmp/\(name).m4a"),

--- a/frontend/OnVoiceTests/RecordingRowSwipeBehaviorTests.swift
+++ b/frontend/OnVoiceTests/RecordingRowSwipeBehaviorTests.swift
@@ -107,4 +107,57 @@ final class RecordingRowSwipeBehaviorTests: XCTestCase {
             rowID
         )
     }
+
+    func testRecordingListOrganizerSplitsHomeAndLibraryByRelativeDate() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "Asia/Seoul")!
+
+        let now = calendar.date(from: DateComponents(year: 2026, month: 4, day: 14, hour: 12))!
+        let todayRecording = makeRecording(
+            named: "Recording_20260414_090000",
+            createdAt: calendar.date(from: DateComponents(year: 2026, month: 4, day: 14, hour: 9))!
+        )
+        let previous7Recording = makeRecording(
+            named: "Recording_20260410_090000",
+            createdAt: calendar.date(from: DateComponents(year: 2026, month: 4, day: 10, hour: 9))!
+        )
+        let previous30Recording = makeRecording(
+            named: "Recording_20260401_090000",
+            createdAt: calendar.date(from: DateComponents(year: 2026, month: 4, day: 1, hour: 9))!
+        )
+        let monthlyRecording = makeRecording(
+            named: "Recording_20260220_090000",
+            createdAt: calendar.date(from: DateComponents(year: 2026, month: 2, day: 20, hour: 9))!
+        )
+
+        let recordings = [monthlyRecording, previous30Recording, previous7Recording, todayRecording]
+
+        let homeItems = withFixedCurrentDate(now) {
+            RecordingListOrganizer.homeItems(from: recordings, calendar: calendar)
+        }
+        let librarySections = withFixedCurrentDate(now) {
+            RecordingListOrganizer.librarySections(from: recordings, calendar: calendar)
+        }
+
+        XCTAssertEqual(homeItems.map(\.recording.id), [todayRecording.id])
+        XCTAssertEqual(librarySections.map(\.title), ["이전 7일", "이전 30일", "2월"])
+        XCTAssertEqual(librarySections[0].items.map(\.recording.id), [previous7Recording.id])
+        XCTAssertEqual(librarySections[1].items.map(\.recording.id), [previous30Recording.id])
+        XCTAssertEqual(librarySections[2].items.map(\.recording.id), [monthlyRecording.id])
+    }
+
+    private func makeRecording(named name: String, createdAt: Date) -> Recording {
+        Recording(
+            fileURL: URL(fileURLWithPath: "/tmp/\(name).m4a"),
+            createdAt: createdAt,
+            duration: 49
+        )
+    }
+
+    private func withFixedCurrentDate<T>(_ date: Date, perform work: () -> T) -> T {
+        let previousDateFactory = RecordingListOrganizer.currentDate
+        RecordingListOrganizer.currentDate = { date }
+        defer { RecordingListOrganizer.currentDate = previousDateFactory }
+        return work()
+    }
 }

--- a/frontend/OnVoiceTests/RecordingRowSwipeBehaviorTests.swift
+++ b/frontend/OnVoiceTests/RecordingRowSwipeBehaviorTests.swift
@@ -132,12 +132,8 @@ final class RecordingRowSwipeBehaviorTests: XCTestCase {
 
         let recordings = [monthlyRecording, previous30Recording, previous7Recording, todayRecording]
 
-        let homeItems = withFixedCurrentDate(now) {
-            RecordingListOrganizer.homeItems(from: recordings, calendar: calendar)
-        }
-        let librarySections = withFixedCurrentDate(now) {
-            RecordingListOrganizer.librarySections(from: recordings, calendar: calendar)
-        }
+        let homeItems = RecordingListOrganizer.homeItems(from: recordings, calendar: calendar, now: now)
+        let librarySections = RecordingListOrganizer.librarySections(from: recordings, calendar: calendar, now: now)
 
         XCTAssertEqual(homeItems.map(\.recording.id), [todayRecording.id])
         XCTAssertEqual(librarySections.map(\.title), ["이전 7일", "이전 30일", "2월"])
@@ -174,9 +170,7 @@ final class RecordingRowSwipeBehaviorTests: XCTestCase {
 
         let recordings = [olderInSameMonth, thirtyOneDaysAgo, thirtyDaysAgo, eightDaysAgo, sevenDaysAgo]
 
-        let librarySections = withFixedCurrentDate(now) {
-            RecordingListOrganizer.librarySections(from: recordings, calendar: calendar)
-        }
+        let librarySections = RecordingListOrganizer.librarySections(from: recordings, calendar: calendar, now: now)
 
         XCTAssertEqual(librarySections.map(\.title), ["이전 7일", "이전 30일", "3월"])
         XCTAssertEqual(librarySections[0].items.map(\.recording.id), [sevenDaysAgo.id])
@@ -221,12 +215,11 @@ final class RecordingRowSwipeBehaviorTests: XCTestCase {
             createdAt: calendar.date(from: DateComponents(year: 2025, month: 12, day: 20, hour: 9))!
         )
 
-        let librarySections = withFixedCurrentDate(now) {
-            RecordingListOrganizer.librarySections(
-                from: [previousYearRecording, currentYearRecording],
-                calendar: calendar
-            )
-        }
+        let librarySections = RecordingListOrganizer.librarySections(
+            from: [previousYearRecording, currentYearRecording],
+            calendar: calendar,
+            now: now
+        )
 
         XCTAssertEqual(librarySections.map(\.title), ["2월", "2025년 12월"])
     }
@@ -247,12 +240,8 @@ final class RecordingRowSwipeBehaviorTests: XCTestCase {
 
         let recordings = [previousLateNight, justAfterMidnight]
 
-        let homeItems = withFixedCurrentDate(now) {
-            RecordingListOrganizer.homeItems(from: recordings, calendar: calendar)
-        }
-        let librarySections = withFixedCurrentDate(now) {
-            RecordingListOrganizer.librarySections(from: recordings, calendar: calendar)
-        }
+        let homeItems = RecordingListOrganizer.homeItems(from: recordings, calendar: calendar, now: now)
+        let librarySections = RecordingListOrganizer.librarySections(from: recordings, calendar: calendar, now: now)
 
         XCTAssertEqual(homeItems.map(\.recording.id), [justAfterMidnight.id])
         XCTAssertEqual(librarySections.map(\.title), ["이전 7일"])
@@ -277,12 +266,11 @@ final class RecordingRowSwipeBehaviorTests: XCTestCase {
             createdAt: calendar.date(from: DateComponents(year: 2026, month: 3, day: 14, hour: 9))!
         )
 
-        let librarySections = withFixedCurrentDate(now) {
-            RecordingListOrganizer.librarySections(
-                from: [thirtyOneDaysAgo, thirtyDaysAgo, sevenDaysAgo],
-                calendar: calendar
-            )
-        }
+        let librarySections = RecordingListOrganizer.librarySections(
+            from: [thirtyOneDaysAgo, thirtyDaysAgo, sevenDaysAgo],
+            calendar: calendar,
+            now: now
+        )
 
         XCTAssertEqual(librarySections.map(\.title), ["이전 7일", "이전 30일", "3월"])
         XCTAssertEqual(librarySections[0].items.map(\.recording.id), [sevenDaysAgo.id])
@@ -298,10 +286,30 @@ final class RecordingRowSwipeBehaviorTests: XCTestCase {
         )
     }
 
-    private func withFixedCurrentDate<T>(_ date: Date, perform work: () -> T) -> T {
-        let previousDateFactory = RecordingListOrganizer.currentDate
-        RecordingListOrganizer.currentDate = { date }
-        defer { RecordingListOrganizer.currentDate = previousDateFactory }
-        return work()
+    func testRecordingListOrganizerUsesStableSectionIDs() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "Asia/Seoul")!
+
+        let now = calendar.date(from: DateComponents(year: 2026, month: 4, day: 14, hour: 12))!
+        let previous7Recording = makeRecording(
+            named: "Recording_20260410_090000",
+            createdAt: calendar.date(from: DateComponents(year: 2026, month: 4, day: 10, hour: 9))!
+        )
+        let previous30Recording = makeRecording(
+            named: "Recording_20260401_090000",
+            createdAt: calendar.date(from: DateComponents(year: 2026, month: 4, day: 1, hour: 9))!
+        )
+        let monthlyRecording = makeRecording(
+            named: "Recording_20260220_090000",
+            createdAt: calendar.date(from: DateComponents(year: 2026, month: 2, day: 20, hour: 9))!
+        )
+
+        let sections = RecordingListOrganizer.librarySections(
+            from: [monthlyRecording, previous30Recording, previous7Recording],
+            calendar: calendar,
+            now: now
+        )
+
+        XCTAssertEqual(sections.map(\.id), ["previous-7-days", "previous-30-days", "month-2026-2"])
     }
 }

--- a/frontend/OnVoiceTests/RecordingRowSwipeBehaviorTests.swift
+++ b/frontend/OnVoiceTests/RecordingRowSwipeBehaviorTests.swift
@@ -259,6 +259,37 @@ final class RecordingRowSwipeBehaviorTests: XCTestCase {
         XCTAssertEqual(librarySections[0].items.map(\.recording.id), [previousLateNight.id])
     }
 
+    func testRecordingListOrganizerPlacesExactThirtyFirstDayIntoMonthlySection() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "Asia/Seoul")!
+
+        let now = calendar.date(from: DateComponents(year: 2026, month: 4, day: 14, hour: 12))!
+        let sevenDaysAgo = makeRecording(
+            named: "Recording_20260407_090000",
+            createdAt: calendar.date(from: DateComponents(year: 2026, month: 4, day: 7, hour: 9))!
+        )
+        let thirtyDaysAgo = makeRecording(
+            named: "Recording_20260315_090000",
+            createdAt: calendar.date(from: DateComponents(year: 2026, month: 3, day: 15, hour: 9))!
+        )
+        let thirtyOneDaysAgo = makeRecording(
+            named: "Recording_20260314_090000",
+            createdAt: calendar.date(from: DateComponents(year: 2026, month: 3, day: 14, hour: 9))!
+        )
+
+        let librarySections = withFixedCurrentDate(now) {
+            RecordingListOrganizer.librarySections(
+                from: [thirtyOneDaysAgo, thirtyDaysAgo, sevenDaysAgo],
+                calendar: calendar
+            )
+        }
+
+        XCTAssertEqual(librarySections.map(\.title), ["이전 7일", "이전 30일", "3월"])
+        XCTAssertEqual(librarySections[0].items.map(\.recording.id), [sevenDaysAgo.id])
+        XCTAssertEqual(librarySections[1].items.map(\.recording.id), [thirtyDaysAgo.id])
+        XCTAssertEqual(librarySections[2].items.map(\.recording.id), [thirtyOneDaysAgo.id])
+    }
+
     private func makeRecording(named name: String, createdAt: Date) -> Recording {
         Recording(
             fileURL: URL(fileURLWithPath: "/tmp/\(name).m4a"),

--- a/frontend/OnVoiceTests/RecordingRowSwipeBehaviorTests.swift
+++ b/frontend/OnVoiceTests/RecordingRowSwipeBehaviorTests.swift
@@ -146,6 +146,91 @@ final class RecordingRowSwipeBehaviorTests: XCTestCase {
         XCTAssertEqual(librarySections[2].items.map(\.recording.id), [monthlyRecording.id])
     }
 
+    func testRecordingListOrganizerUsesCalendarBoundariesAndSortsEachSection() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "Asia/Seoul")!
+
+        let now = calendar.date(from: DateComponents(year: 2026, month: 4, day: 14, hour: 12))!
+        let sevenDaysAgo = makeRecording(
+            named: "Recording_20260407_090000",
+            createdAt: calendar.date(from: DateComponents(year: 2026, month: 4, day: 7, hour: 9))!
+        )
+        let eightDaysAgo = makeRecording(
+            named: "Recording_20260406_090000",
+            createdAt: calendar.date(from: DateComponents(year: 2026, month: 4, day: 6, hour: 9))!
+        )
+        let thirtyDaysAgo = makeRecording(
+            named: "Recording_20260315_090000",
+            createdAt: calendar.date(from: DateComponents(year: 2026, month: 3, day: 15, hour: 9))!
+        )
+        let thirtyOneDaysAgo = makeRecording(
+            named: "Recording_20260314_090000",
+            createdAt: calendar.date(from: DateComponents(year: 2026, month: 3, day: 14, hour: 9))!
+        )
+        let olderInSameMonth = makeRecording(
+            named: "Recording_20260301_090000",
+            createdAt: calendar.date(from: DateComponents(year: 2026, month: 3, day: 1, hour: 9))!
+        )
+
+        let recordings = [olderInSameMonth, thirtyOneDaysAgo, thirtyDaysAgo, eightDaysAgo, sevenDaysAgo]
+
+        let librarySections = withFixedCurrentDate(now) {
+            RecordingListOrganizer.librarySections(from: recordings, calendar: calendar)
+        }
+
+        XCTAssertEqual(librarySections.map(\.title), ["이전 7일", "이전 30일", "3월"])
+        XCTAssertEqual(librarySections[0].items.map(\.recording.id), [sevenDaysAgo.id])
+        XCTAssertEqual(librarySections[1].items.map(\.recording.id), [eightDaysAgo.id, thirtyDaysAgo.id])
+        XCTAssertEqual(librarySections[2].items.map(\.recording.id), [thirtyOneDaysAgo.id, olderInSameMonth.id])
+    }
+
+    func testDisplayTitleUsesFallbackOnlyForGeneratedDefaultTitle() {
+        let defaultTitleRecording = makeRecording(
+            named: "Recording_20260414_090000",
+            createdAt: Date(timeIntervalSince1970: 0)
+        )
+        let customTitleRecording = makeRecording(
+            named: "회의 메모",
+            createdAt: Date(timeIntervalSince1970: 1)
+        )
+
+        let defaultTitleItem = RecordingDisplayItem(
+            index: 1,
+            recording: defaultTitleRecording
+        )
+        let customTitleItem = RecordingDisplayItem(
+            index: 2,
+            recording: customTitleRecording
+        )
+
+        XCTAssertEqual(RecordingListOrganizer.displayTitle(for: customTitleItem), "회의 메모")
+        XCTAssertEqual(RecordingListOrganizer.displayTitle(for: defaultTitleItem), "새로운 대화 기록 (1)")
+    }
+
+    func testMonthSectionTitleIncludesYearOnlyForPastYears() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "Asia/Seoul")!
+
+        let now = calendar.date(from: DateComponents(year: 2026, month: 4, day: 14, hour: 12))!
+        let currentYearRecording = makeRecording(
+            named: "Recording_20260220_090000",
+            createdAt: calendar.date(from: DateComponents(year: 2026, month: 2, day: 20, hour: 9))!
+        )
+        let previousYearRecording = makeRecording(
+            named: "Recording_20251220_090000",
+            createdAt: calendar.date(from: DateComponents(year: 2025, month: 12, day: 20, hour: 9))!
+        )
+
+        let librarySections = withFixedCurrentDate(now) {
+            RecordingListOrganizer.librarySections(
+                from: [previousYearRecording, currentYearRecording],
+                calendar: calendar
+            )
+        }
+
+        XCTAssertEqual(librarySections.map(\.title), ["2월", "2025년 12월"])
+    }
+
     private func makeRecording(named name: String, createdAt: Date) -> Recording {
         Recording(
             fileURL: URL(fileURLWithPath: "/tmp/\(name).m4a"),


### PR DESCRIPTION
## Summary
홈 화면과 라이브러리 화면의 녹음 목록 노출 기준을 분리하고, 라이브러리에서도 녹음 목록을 날짜 구간별로 정리해 볼 수 있도록 구현했습니다.  
오늘 생성한 녹음은 홈 화면에만 표시되고, 어제까지의 녹음은 라이브러리에서 최신순 및 날짜 섹션 기준으로 확인할 수 있습니다.  
또한 라이브러리의 빈 상태 워터마크 위치를 홈 화면과 동일하게 맞춰 탭 전환 시 위화감이 없도록 정리했습니다.


## Related Issue
- issue: #38 


## Changes (변경 사항)
- 홈 화면 녹음 목록을 오늘 생성한 녹음만 표시하도록 변경
- 라이브러리 화면에 오늘 이전 녹음 목록 표시 기능 추가
- 라이브러리 녹음 목록을 최신순으로 정렬하도록 적용
- 라이브러리 녹음 목록을 `이전 7일`, `이전 30일`, 월별 섹션으로 구분하도록 구현
- 라이브러리에서도 녹음 상세 진입, 이름 수정, 삭제가 가능하도록 연결
- 녹음 목록 필터링 및 섹션 분류 로직을 공용 유틸로 분리
- 라이브러리 빈 상태 워터마크 위치를 홈 화면과 동일한 레이아웃으로 정렬
- 날짜 기준 분리 및 섹션 분류 로직에 대한 테스트 추가


## Test
- [x] 로컬에서 테스트 완료
- [x] 기존 기능에 영향 없음

추가 테스트 내용
- `xcodebuild test -project frontend/OnVoice.xcodeproj -scheme OnVoice -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4' -only-testing:OnVoiceTests` 실행
- `RecordingRowSwipeBehaviorTests` 내 날짜 분리 로직 테스트 통과 확인
- 더미데이터 추가하여 UI 테스트 확인


## Screenshots (Optional)
| 더미데이터 없는 뷰 | 더미데이터 추가한 뷰 |
|:--:|:--:|
| <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/8d96e61a-7169-4ead-b9d1-ae19825947c2" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-14 at 22 30 27" src="https://github.com/user-attachments/assets/c013c8c6-6ce2-40ad-aca4-48aa1e68b6e4" /> |


## Checklist
- [ ] 변경사항 400줄 이하
- [x] 필요시 테스트 추가
- [ ] 필요시 문서 업데이트


## Additional Context (추가 사항)
- 라이브러리의 월별 섹션 제목은 기본적으로 `n월` 형식으로 표시되며, 연도가 달라지는 경우에는 구분을 위해 `yyyy년 n월` 형식으로 표시되도록 처리했습니다.
- SwiftUI 타입 체크 비용으로 인한 빌드 오류를 피하기 위해 `LibraryView`의 섹션 및 행 렌더링을 작은 뷰 단위로 분리했습니다.