### PR TITLE
chore: 홈 앱 표시 이름 변경

### DIFF
--- a/frontend/OnVoice.xcodeproj/project.pbxproj
+++ b/frontend/OnVoice.xcodeproj/project.pbxproj
@@ -494,7 +494,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OnVoice/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = I;
+				INFOPLIST_KEY_CFBundleDisplayName = "밍글리";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "음성 녹음을 위해 마이크 접근 권한이 필요합니다.";
 				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "음성 내용을 분석하기 위해 음성 인식 권한이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -528,7 +528,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OnVoice/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = I;
+				INFOPLIST_KEY_CFBundleDisplayName = "밍글리";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "음성 녹음을 위해 마이크 접근 권한이 필요합니다.";
 				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "음성 내용을 분석하기 위해 음성 인식 권한이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;


### PR DESCRIPTION
## Summary
<!-- 이 PR의 목적과 주요 변경 사항을 간단히 설명하세요. -->
앱의 표시 이름(Display Name)을 변경하여 사용자에게 노출되는 앱 이름을 수정했습니다.


## Changes (변경 사항)
<!-- 주요 변경 사항을 목록으로 작성하세요. (예: `컴포넌트 A의 스타일 수정`, `API 요청 로직 개선`) -->
- Info.plist에서 앱 표시 이름 변경
- Xcode 프로젝트 설정 내 Display Name 수정
