### PR TITLE
design: expanded 다이나믹 아일랜드 UI를 피그마 시안에 맞게 재구성

### DIFF
--- a/frontend/DynamicIsland/DynamicIslandLiveActivity.swift
+++ b/frontend/DynamicIsland/DynamicIslandLiveActivity.swift
@@ -5,6 +5,17 @@ import SwiftUI
 struct DynamicIslandWidgetLiveActivity: Widget {
     private let metricBadgeWidth: CGFloat = 95
     private let barHeight: CGFloat = 48
+    private let expandedProgressBarWidth: CGFloat = 329
+    private let expandedProgressBarHeight: CGFloat = 29
+    private let expandedTopInset: CGFloat = 11
+    private let expandedHorizontalInset: CGFloat = 11
+    private let expandedMetricLeadingInset: CGFloat = 18
+    private let expandedTrailingInset: CGFloat = 18
+    private let expandedProgressHorizontalInset: CGFloat = 21
+    private let expandedBottomInset: CGFloat = 18
+    private let closeButtonSize: CGFloat = 42
+    private let subTextColor = Color(red: 221 / 255, green: 232 / 255, blue: 253 / 255)
+    private let gray9Color = Color(red: 46 / 255, green: 48 / 255, blue: 58 / 255)
 
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: OnVoiceLiveActivityAttributes.self) { context in
@@ -41,32 +52,47 @@ struct DynamicIslandWidgetLiveActivity: Widget {
         } dynamicIsland: { context in
             DynamicIsland {
                 DynamicIslandExpandedRegion(.leading) {
-                    HStack(alignment: .bottom) {
+                    HStack {
                         metricBadge(for: context.state, valueWidth: 35)
-                        .padding(.leading, 8)
+                        Spacer(minLength: 0)
                     }
+                    .padding(.leading, expandedMetricLeadingInset)
+                    .padding(.top, expandedTopInset)
                 }
-                
+
                 DynamicIslandExpandedRegion(.trailing) {
-                    Image(systemName: symbolName(for: context.state.level))
-                        .font(.title2)
-                        .foregroundStyle(fillColor(for: context.state))
-                        .frame(width: 40, height: 40)
-                        .padding(.trailing, 11)
+                    ZStack {
+                        Circle()
+                            .fill(Color.white.opacity(0.12))
+
+                        Image(systemName: "xmark")
+                            .font(.system(size: 18, weight: .regular))
+                            .foregroundStyle(Color.white.opacity(0.7))
+                    }
+                    .frame(width: closeButtonSize, height: closeButtonSize)
+                    .padding(.trailing, expandedTrailingInset)
+                    .padding(.top, expandedTopInset)
                 }
-                
+
                 DynamicIslandExpandedRegion(.center) {
-                    Text(context.state.title)
-                        .font(.footnote)
-                        .foregroundStyle(.white.opacity(0.8))
+                    Color.clear
                 }
 
                 DynamicIslandExpandedRegion(.bottom) {
-                    GeometryReader { geometry in
-                        progressBar(for: context.state, width: geometry.size.width, height: 29)
+                    VStack(spacing: 0) {
+                        Spacer(minLength: 0)
+                        HStack {
+                            progressBar(
+                                for: context.state,
+                                width: expandedProgressBarWidth,
+                                height: expandedProgressBarHeight
+                            )
+                            .frame(width: expandedProgressBarWidth, height: expandedProgressBarHeight)
+                        }
+                        .padding(.horizontal, expandedProgressHorizontalInset)
+                        .padding(.bottom, expandedBottomInset)
                     }
-                    .padding(.bottom, 18)
-                    .padding(.horizontal, 11)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
                 }
             } compactLeading: {
                 compactDecibelView(for: context.state)
@@ -75,6 +101,10 @@ struct DynamicIslandWidgetLiveActivity: Widget {
             } minimal: {
                 minimalLevelIndicator(for: context.state)
             }
+            .contentMargins(.top, expandedTopInset, for: .expanded)
+            .contentMargins(.leading, expandedHorizontalInset, for: .expanded)
+            .contentMargins(.trailing, expandedHorizontalInset, for: .expanded)
+            .contentMargins(.bottom, 0, for: .expanded)
             .keylineTint(borderColor(for: context.state))
         }
     }
@@ -98,12 +128,12 @@ struct DynamicIslandWidgetLiveActivity: Widget {
 
                 Text("\(state.decibels)")
                     .font(.title3.weight(.semibold))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(subTextColor)
                     .frame(width: valueWidth)
 
                 Text("dB")
                     .font(.subheadline)
-                    .foregroundStyle(.white)
+                    .foregroundStyle(subTextColor)
                     .padding(.top, 3)
             }
         }
@@ -119,7 +149,7 @@ struct DynamicIslandWidgetLiveActivity: Widget {
 
         ZStack(alignment: .leading) {
             RoundedRectangle(cornerRadius: 24)
-                .fill(Color.gray.opacity(0.3))
+                .fill(gray9Color)
                 .frame(width: width, height: height)
 
             RoundedRectangle(cornerRadius: 24)
@@ -246,19 +276,6 @@ struct DynamicIslandWidgetLiveActivity: Widget {
             return "😮"
         case .idle:
             return "🔇"
-        }
-    }
-
-    private func symbolName(for level: OnVoiceLiveActivityAttributes.Level) -> String {
-        switch level {
-        case .low:
-            return "speaker.wave.1.fill"
-        case .medium:
-            return "speaker.wave.2.fill"
-        case .high:
-            return "speaker.wave.3.fill"
-        case .idle:
-            return "speaker.slash.fill"
         }
     }
 


### PR DESCRIPTION
## Summary
expanded 다이나믹 아일랜드 UI를 피그마 시안 기준으로 재구성했습니다.
기존의 `leading / trailing / center / bottom` 기본 분할 느낌을 줄이고, 상단의 dB 배지와 닫기 버튼, 하단의 progress bar가 하나의 카드처럼 보이도록 레이아웃을 정리했습니다.


## Related Issue
- issue: #55  


## Changes (변경 사항)
- expanded Dynamic Island의 상단 레이아웃을 `dB 배지 + 닫기 버튼` 구조로 재구성
- center 영역의 텍스트와 trailing 스피커 아이콘 제거
- expanded 전용 여백과 치수(`11 / 18 / 21 / 329x29`)를 상수로 분리
- 하단 progress bar를 피그마 시안 기준 크기와 위치로 조정
- progress bar 배경색을 더 진한 회색으로 변경해 시안과 유사하게 보정


## Test
- [x] 로컬에서 테스트 완료
- [x] 기존 기능에 영향 없음

테스트 내용
- `xcodebuild build -project frontend/OnVoice.xcodeproj -scheme DynamicIsland -destination 'generic/platform=iOS Simulator'` 빌드 성공 확인


## Screenshots (Optional)
| expanded Dynamic Island UI | 보간 | 전환 이후 |
|:--:|:--:|:--:|
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-04 at 16 46 40" src="https://github.com/user-attachments/assets/06bf0a6e-0160-4cf9-9bd1-7de98e444702" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-04 at 16 47 04" src="https://github.com/user-attachments/assets/6e14fa27-47d2-4a5f-a0e0-5d37a951801f" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-04 at 16 47 27" src="https://github.com/user-attachments/assets/b33d38eb-0466-484c-916f-e2e6b2d139b3" /> |

## Checklist
- [x] 변경사항 400줄 이하
- [ ] 필요시 테스트 추가
- [ ] 필요시 문서 업데이트


## Additional Context (Optional)
현재 우상단 `x` 버튼은 시안 반영을 위한 시각 요소 중심으로 적용되어 있습니다.
실제 Live Activity 종료 액션 연결 여부는 후속 작업에서 별도로 반영할 수 있습니다.