### PR TITLE
feat: expanded Dynamic Island UI 개선 및 X 버튼 종료 플로우 정리

### DIFF
--- a/frontend/DynamicIsland/DynamicIslandLiveActivity.swift
+++ b/frontend/DynamicIsland/DynamicIslandLiveActivity.swift
@@ -265,7 +265,7 @@ struct DynamicIslandWidgetLiveActivity: Widget {
     }
 
     private var closeButton: some View {
-        Button(intent: EndExpandedLiveActivityIntent()) {
+        Button(intent: EndLiveActivityIntent()) {
             Image(systemName: "xmark")
                 .font(.system(size: 19, weight: .light))
                 .foregroundStyle(subColor.opacity(0.82))
@@ -455,16 +455,5 @@ struct DynamicIslandWidgetLiveActivity: Widget {
             self.blue = blue
             self.alpha = alpha
         }
-    }
-}
-
-private struct EndExpandedLiveActivityIntent: LiveActivityIntent {
-    static var title: LocalizedStringResource = "End Live Activity"
-
-    func perform() async throws -> some IntentResult {
-        for activity in Activity<OnVoiceLiveActivityAttributes>.activities {
-            await activity.end(nil, dismissalPolicy: .immediate)
-        }
-        return .result()
     }
 }

--- a/frontend/DynamicIsland/DynamicIslandLiveActivity.swift
+++ b/frontend/DynamicIsland/DynamicIslandLiveActivity.swift
@@ -104,7 +104,7 @@ struct DynamicIslandWidgetLiveActivity: Widget {
     @ViewBuilder
     private func metricBadge(
         for state: OnVoiceLiveActivityAttributes.ContentState,
-        valueWidth: CGFloat = 0
+        valueWidth: CGFloat = 30
     ) -> some View {
         let badgeGradient = levelGradient(for: state)
 
@@ -129,7 +129,7 @@ struct DynamicIslandWidgetLiveActivity: Widget {
                 Text("dB")
                     .font(.system(size: 16, weight: .regular))
                     .foregroundStyle(subColor)
-                    //.padding(.bottom, 2)
+                    .padding(.top, 4)
             }
             //.padding(.horizontal, 6)
             //.padding(.vertical, 4)

--- a/frontend/DynamicIsland/DynamicIslandLiveActivity.swift
+++ b/frontend/DynamicIsland/DynamicIslandLiveActivity.swift
@@ -1,4 +1,5 @@
 import ActivityKit
+import AppIntents
 import SwiftUI
 import WidgetKit
 
@@ -9,6 +10,16 @@ struct DynamicIslandWidgetLiveActivity: Widget {
     private let progressBarHeight: CGFloat = 48
     private let rowSpacing: CGFloat = 8
     private let horizontalInset: CGFloat = 24
+    private let expandedCloseButtonSize: CGFloat = 40
+    private let expandedProgressBarHeight: CGFloat = 29
+    private let expandedHorizontalInset: CGFloat = 12
+    private let expandedTopInset: CGFloat = 0
+    private let expandedBottomInset: CGFloat = 4
+    private let expandedRowBottomSpacing: CGFloat = 6
+    private let expandedLeadingInset: CGFloat = 0
+    private let expandedTrailingInset: CGFloat = 0
+    private let expandedBarLeadingAdjustment: CGFloat = 0
+    private let expandedBarTrailingAdjustment: CGFloat = 0
 
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: OnVoiceLiveActivityAttributes.self) { context in
@@ -20,38 +31,19 @@ struct DynamicIslandWidgetLiveActivity: Widget {
         } dynamicIsland: { context in
             DynamicIsland {
                 DynamicIslandExpandedRegion(.leading) {
-                    HStack(alignment: .bottom) {
-                        metricBadge(for: context.state, valueWidth: 35)
-                            .padding(.leading, 8)
-                    }
+                    expandedLeadingContent(for: context.state)
                 }
 
                 DynamicIslandExpandedRegion(.trailing) {
-                    Image(systemName: symbolName(for: context.state.level))
-                        .font(.title2)
-                        .foregroundStyle(fillColor(for: context.state))
-                        .frame(width: 40, height: 40)
-                        .padding(.trailing, 11)
+                    expandedTrailingContent
                 }
 
                 DynamicIslandExpandedRegion(.center) {
-                    Text(context.state.title)
-                        .font(.footnote)
-                        .foregroundStyle(subColor.opacity(0.78))
-                        .lineLimit(1)
+                    EmptyView()
                 }
 
                 DynamicIslandExpandedRegion(.bottom) {
-                    GeometryReader { geometry in
-                        progressBar(
-                            for: context.state,
-                            width: geometry.size.width,
-                            height: 29,
-                            cornerRadius: 14.5
-                        )
-                    }
-                    .padding(.bottom, 18)
-                    .padding(.horizontal, 11)
+                    expandedBottomContent(for: context.state)
                 }
             } compactLeading: {
                 compactDecibelView(for: context.state)
@@ -112,7 +104,7 @@ struct DynamicIslandWidgetLiveActivity: Widget {
     @ViewBuilder
     private func metricBadge(
         for state: OnVoiceLiveActivityAttributes.ContentState,
-        valueWidth: CGFloat = 30
+        valueWidth: CGFloat = 0
     ) -> some View {
         let badgeGradient = levelGradient(for: state)
 
@@ -137,12 +129,60 @@ struct DynamicIslandWidgetLiveActivity: Widget {
                 Text("dB")
                     .font(.system(size: 16, weight: .regular))
                     .foregroundStyle(subColor)
-                    .padding(.bottom, 2)
+                    //.padding(.bottom, 2)
             }
             //.padding(.horizontal, 6)
-            .padding(.vertical, 4)
+            //.padding(.vertical, 4)
         }
         .frame(width: metricBadgeWidth, height: metricBadgeHeight)
+    }
+
+    @ViewBuilder
+    private func expandedLeadingContent(
+        for state: OnVoiceLiveActivityAttributes.ContentState
+    ) -> some View {
+        metricBadge(for: state, valueWidth: 28)
+        .padding(.top, expandedTopInset)
+        .padding(.bottom, expandedBottomInset)
+        .padding(.leading, expandedLeadingInset)
+        .padding(.trailing, expandedTrailingInset)
+    }
+
+    private var expandedTrailingContent: some View {
+        closeButton
+            .padding(.top, expandedTopInset)
+            .padding(.bottom, expandedBottomInset)
+            .padding(.leading, expandedLeadingInset)
+            .padding(.trailing, expandedTrailingInset)
+    }
+
+    @ViewBuilder
+    private func expandedBottomContent(
+        for state: OnVoiceLiveActivityAttributes.ContentState
+    ) -> some View {
+        GeometryReader { geometry in
+            progressBar(
+                for: state,
+                width: max(
+                    0,
+                    geometry.size.width
+                    - expandedBarLeadingAdjustment
+                    - expandedBarTrailingAdjustment
+                ),
+                height: expandedProgressBarHeight,
+                cornerRadius: expandedProgressBarHeight / 2
+            )
+            .frame(
+                width: geometry.size.width,
+                height: geometry.size.height,
+                alignment: .leading
+            )
+            .padding(.leading, expandedBarLeadingAdjustment)
+            .padding(.trailing, expandedBarTrailingAdjustment)
+        }
+        .frame(height: expandedProgressBarHeight)
+        .padding(.top, expandedRowBottomSpacing)
+        .padding(.bottom, expandedBottomInset)
     }
 
     @ViewBuilder
@@ -153,20 +193,21 @@ struct DynamicIslandWidgetLiveActivity: Widget {
         cornerRadius: CGFloat
     ) -> some View {
         let clampedProgress = min(max(CGFloat(state.progress) / 100, 0), 1)
-        let fillWidth = width * clampedProgress
         let isIdle = state.level == .idle || state.progress == 0
+        let rawFillWidth = width * clampedProgress
+        let fillWidth = isIdle ? 0 : max(rawFillWidth, height)
 
         ZStack(alignment: .leading) {
-            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+            Capsule(style: .continuous)
                 .fill(gray9Color)
                 .frame(width: width, height: height)
 
-            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+            Capsule(style: .continuous)
                 .fill(levelGradient(for: state))
                 .frame(width: isIdle ? 0 : fillWidth, height: height)
                 .overlay(alignment: .trailing) {
                     if !isIdle {
-                        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                        Capsule(style: .continuous)
                             .fill(.white.opacity(0.16))
                             .frame(width: min(height * 0.42, fillWidth), height: height * 0.74)
                             .blur(radius: 8)
@@ -223,6 +264,20 @@ struct DynamicIslandWidgetLiveActivity: Widget {
             .frame(width: 20, height: 20)
     }
 
+    private var closeButton: some View {
+        Button(intent: EndExpandedLiveActivityIntent()) {
+            Image(systemName: "xmark")
+                .font(.system(size: 19, weight: .light))
+                .foregroundStyle(subColor.opacity(0.82))
+                .frame(width: expandedCloseButtonSize, height: expandedCloseButtonSize)
+                .background(
+                    Circle()
+                        .fill(Color.white.opacity(0.14))
+                )
+        }
+        .buttonStyle(.plain)
+    }
+
     private var lockScreenBackgroundColor: Color {
         Color(red: 34 / 255, green: 34 / 255, blue: 34 / 255)
     }
@@ -259,16 +314,16 @@ struct DynamicIslandWidgetLiveActivity: Widget {
                     gray8Color.opacity(0.95),
                     gray9Color
                 ],
-                startPoint: .leading,
-                endPoint: .trailing
+                startPoint: .trailing,
+                endPoint: .leading
             )
         }
 
         let gradientColors = gradientColors(for: state)
         return LinearGradient(
             colors: gradientColors,
-            startPoint: .leading,
-            endPoint: .trailing
+            startPoint: .trailing,
+            endPoint: .leading
         )
     }
 
@@ -400,5 +455,16 @@ struct DynamicIslandWidgetLiveActivity: Widget {
             self.blue = blue
             self.alpha = alpha
         }
+    }
+}
+
+private struct EndExpandedLiveActivityIntent: LiveActivityIntent {
+    static var title: LocalizedStringResource = "End Live Activity"
+
+    func perform() async throws -> some IntentResult {
+        for activity in Activity<OnVoiceLiveActivityAttributes>.activities {
+            await activity.end(nil, dismissalPolicy: .immediate)
+        }
+        return .result()
     }
 }

--- a/frontend/OnVoice.xcodeproj/project.pbxproj
+++ b/frontend/OnVoice.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		F0A100042F90000100ABCD01 /* LiveActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A100072F90000100ABCD01 /* LiveActivityAttributes.swift */; };
 		F0A100152F90000100ABCD01 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CE2FE5E12E30D69500C90F26 /* Assets.xcassets */; };
 		F0A100132F90000100ABCD01 /* LiveActivityState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A100142F90000100ABCD01 /* LiveActivityState.swift */; };
+		F0A100162F90000100ABCD01 /* AppIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2FE5E02E30D69500C90F26 /* AppIntent.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -406,6 +407,7 @@
 			files = (
 				F0A100022F90000100ABCD01 /* DynamicIslandBundle.swift in Sources */,
 				F0A100032F90000100ABCD01 /* DynamicIslandLiveActivity.swift in Sources */,
+				F0A100162F90000100ABCD01 /* AppIntent.swift in Sources */,
 				F0A100042F90000100ABCD01 /* LiveActivityAttributes.swift in Sources */,
 				F0A100132F90000100ABCD01 /* LiveActivityState.swift in Sources */,
 			);

--- a/frontend/OnVoice/Application/AppDelegate.swift
+++ b/frontend/OnVoice/Application/AppDelegate.swift
@@ -12,7 +12,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // 앱이 종료될때 실행
     func applicationWillTerminate(_ application: UIApplication) {
         print(#function)
-        NoiseMeter.shared.endLiveActivity()
+        Task {
+            await NoiseMeter.shared.endLiveActivity()
+        }
         print("[앱 강제종료 됨 : endLiveActivity Done]")
     }
 }

--- a/frontend/OnVoice/Application/OnVoiceApp.swift
+++ b/frontend/OnVoice/Application/OnVoiceApp.swift
@@ -11,7 +11,7 @@ import SwiftData
 @main
 struct OnVoiceApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-    @StateObject var recorder = AudioRecorder()
+    @StateObject private var recorder = AudioRecorder.shared
 
     var body: some Scene {
         WindowGroup {

--- a/frontend/OnVoice/Service/AudioRecord.swift
+++ b/frontend/OnVoice/Service/AudioRecord.swift
@@ -42,6 +42,8 @@ struct Recording: Identifiable, Hashable {
 }
 
 class AudioRecorder: ObservableObject {
+    static let shared = AudioRecorder()
+
     @Published var recordings: [Recording] = []
     
     private var recorder: AVAudioRecorder?
@@ -94,12 +96,20 @@ class AudioRecorder: ObservableObject {
     }
     
     func stop() {
-        recorder?.stop()
-        if let url = recorder?.url {
+        guard let recorder else { return }
+
+        let shouldPersistRecording = recorder.isRecording || recorder.currentTime > 0
+        recorder.stop()
+
+        if shouldPersistRecording {
+            let url = recorder.url
             let duration = getAccurateAudioDuration(from: url)
             let recording = Recording(fileURL: url, createdAt: Date(), duration: duration)
             recordings.append(recording)
         }
+
+        self.recorder = nil
+        startTime = nil
     }
 
     func deleteRecording(_ recording: Recording) throws {

--- a/frontend/OnVoice/Service/NoiseMeter.swift
+++ b/frontend/OnVoice/Service/NoiseMeter.swift
@@ -140,15 +140,22 @@ class NoiseMeter{
     }
     
     /// Live Activity를 종료하는 함수
-    func endLiveActivity() {
+    @MainActor
+    func endLiveActivity() async {
         print(#function)
-        Task {
-            if let currentActivity = activity {
-                await currentActivity.end(nil, dismissalPolicy: .immediate)
-                print("Ending the Live Activity: \(currentActivity.id)")
-                self.activity = nil
-            }
+        let activeActivities: [Activity<OnVoiceLiveActivityAttributes>]
+        if let currentActivity = activity {
+            activeActivities = [currentActivity]
+        } else {
+            activeActivities = Activity<OnVoiceLiveActivityAttributes>.activities
         }
+
+        for currentActivity in activeActivities {
+            await currentActivity.end(nil, dismissalPolicy: .immediate)
+            print("Ending the Live Activity: \(currentActivity.id)")
+        }
+
+        self.activity = nil
         cancellation?.cancel()
         updateTimer?.invalidate()
         updateTimer = nil

--- a/frontend/OnVoice/Shared/EndLiveActivityIntent.swift
+++ b/frontend/OnVoice/Shared/EndLiveActivityIntent.swift
@@ -4,6 +4,7 @@ struct EndLiveActivityIntent: LiveActivityIntent {
     static var title: LocalizedStringResource = "End Live Activity"
 
     func perform() async throws -> some IntentResult {
+        await RecordingSessionController.shared.terminateActiveSession()
         return .result()
     }
 }

--- a/frontend/OnVoice/Shared/RecordingSessionController.swift
+++ b/frontend/OnVoice/Shared/RecordingSessionController.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+@MainActor
+final class RecordingSessionController: ObservableObject {
+    static let shared = RecordingSessionController()
+
+    @Published private(set) var terminationCount = 0
+
+    private init() {}
+
+    func terminateActiveSession() async {
+        AudioRecorder.shared.stop()
+        await NoiseMeter.shared.endLiveActivity()
+        terminationCount += 1
+    }
+}

--- a/frontend/OnVoice/View/FeedbackView.swift
+++ b/frontend/OnVoice/View/FeedbackView.swift
@@ -18,6 +18,7 @@ struct FeedbackView: View {
     
     @Environment(\.dismiss) private var dismiss
     @EnvironmentObject var recorder: AudioRecorder
+    @ObservedObject private var sessionController = RecordingSessionController.shared
     @AppStorage("shouldSkipVoicePitchGuide") private var shouldSkipVoicePitchGuide = false
     @State private var isPaused = false
     @State private var guideSheetState = VoicePitchGuideSheetState()
@@ -61,10 +62,8 @@ struct FeedbackView: View {
                         // 종료 버튼
                         Button {
                             Task {
-                                recorder.stop()
-                                await noiseMeter.endLiveActivity()
+                                await terminateSessionAndDismiss()
                             }
-                            dismiss()
                         } label: {
                             Text("종료")
                                 .font(.Pretendard.Regular.size17)
@@ -109,8 +108,17 @@ struct FeedbackView: View {
                 guideSheetState = VoicePitchGuideSheetState()
                 currentSituation = nil
             }
+            .onChange(of: sessionController.terminationCount) { _, _ in
+                dismiss()
+            }
         }
         .toolbar(.hidden, for: .tabBar)
+    }
+
+    @MainActor
+    private func terminateSessionAndDismiss() async {
+        await sessionController.terminateActiveSession()
+        dismiss()
     }
 
     private var guideSheetOverlay: some View {


### PR DESCRIPTION
## Summary
expanded Dynamic Island UI를 레이아웃 기준으로 재구성하고, expand UI의 `X` 버튼 종료 플로우를 실제 녹음 종료 시나리오에 맞게 정리했습니다.

이번 변경으로 expanded 상태에서 dB 배지, 종료 버튼, progress bar의 배치가 더 안정적으로 보이도록 조정했고, `X` 버튼을 눌렀을 때 앱으로 복귀하지 않으면서도 녹음 저장, 측정 종료, Live Activity 종료가 함께 수행되도록 백그라운드 종료 경로를 구성했습니다.


## Related Issue
- issue: #55 


## Changes (변경 사항)
- expanded Dynamic Island UI를 `leading / trailing / bottom` 영역 구조로 재구성
- dB 배지와 `X` 버튼을 상단에 배치해 expanded UI의 상단 여백과 시각 균형 개선
- expanded 전용 spacing 상수와 progress bar 레이아웃 함수를 분리해 유지보수성 향상
- progress bar를 `Capsule` 기반으로 정리하고 gradient 방향, 내부 정렬을 다듬어 시각 일관성 개선
- expanded UI에서 즉시 종료 가능한 `X` 버튼 인터랙션 추가
- `X` 버튼을 앱 복귀 링크 대신 백그라운드 `LiveActivityIntent` 기반 종료 액션으로 변경
- 녹음 종료, 파일 저장, 측정 종료, Live Activity 종료를 `RecordingSessionController` 경로로 통합
- `AudioRecorder`를 싱글톤 기반으로 정리해 백그라운드 intent에서도 동일한 녹음 세션 제어 가능하도록 수정
- `NoiseMeter.endLiveActivity()`가 인메모리 참조뿐 아니라 시스템의 활성 Live Activity 목록 기준으로 종료되도록 보강
- 피드백 화면 상단 `종료` 버튼도 동일한 종료 플로우를 사용하도록 정리


## Test
- [x] 로컬에서 테스트 완료
- [x] 기존 기능에 영향 없음

테스트 내용
- `DynamicIsland` 스킴 빌드 성공 확인
- `OnVoice` 스킴 빌드 성공 확인
- expanded Live Activity에서 `X` 버튼 탭 시 앱 복귀 없이 녹음 종료 및 저장 동작 확인
- 녹음 종료 후 Live Activity가 즉시 사라지는지 확인
- 피드백 화면 상단 `종료` 버튼이 동일한 종료 경로를 사용하는지 확인


## Screenshots (Optional)
| expanded UI 레이아웃 정리 | `x`버튼 누르면 백그라운드 종료 | 앱 접속 시 녹음 내용 저장 확인 가능 |
|:--:|:--:|:--:|
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-05 at 05 07 01" src="https://github.com/user-attachments/assets/0560a8f9-3e53-42ae-bfff-cfc459aaaf17" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-05 at 06 11 59" src="https://github.com/user-attachments/assets/00924b73-9d9b-4590-b221-2d4d8646c704" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-05 at 06 12 02" src="https://github.com/user-attachments/assets/85c81d20-2c4d-446d-b032-6cd2eca2f1f4" /> |


## Checklist
- [x] 변경사항 400줄 이하
- [ ] 필요시 테스트 추가
- [ ] 필요시 문서 업데이트


## Additional Context (Optional)
- 현재 브랜치에는 `expanded Dynamic Island UI 레이아웃 개선`과 `X 버튼 종료 플로우 정리` 작업이 함께 포함되어 있습니다.
- `X` 버튼은 앱을 foreground로 띄우지 않고 종료 액션만 수행하도록 구성했습니다.
- Live Activity 종료 시 `NoiseMeter.shared.activity` 참조가 없는 경우에도 시스템의 활성 Live Activity 목록에서 직접 종료하도록 보강했습니다.
