### PR TITLE
feat: 마이페이지 프로필 이미지 수정 기능 구현

### DIFF
--- a/frontend/OnVoice/Application/ContentView.swift
+++ b/frontend/OnVoice/Application/ContentView.swift
@@ -18,6 +18,7 @@ enum OnVoiceFlow: Equatable {
 struct ContentView: View {
     @State private var selectedTab: OnVoiceTab = .home
     @State private var flow: OnVoiceFlow = .login
+    @State private var userProfile = UserProfile.placeholder
 
     var body: some View {
         Group {
@@ -27,15 +28,16 @@ struct ContentView: View {
                     flow = .profileSetup
                 }
             case .profileSetup:
-                ProfileSetupView {
+                ProfileSetupView { profile in
+                    userProfile = profile
                     flow = .app
                 }
             case .app:
                 switch selectedTab {
                 case .home:
-                    HomeView(selectedTab: $selectedTab)
+                    HomeView(selectedTab: $selectedTab, userProfile: userProfile)
                 case .library:
-                    LibraryView(selectedTab: $selectedTab)
+                    LibraryView(selectedTab: $selectedTab, userProfile: userProfile)
                 }
             }
         }

--- a/frontend/OnVoice/Application/ContentView.swift
+++ b/frontend/OnVoice/Application/ContentView.swift
@@ -35,9 +35,9 @@ struct ContentView: View {
             case .app:
                 switch selectedTab {
                 case .home:
-                    HomeView(selectedTab: $selectedTab, userProfile: userProfile)
+                    HomeView(selectedTab: $selectedTab, userProfile: $userProfile)
                 case .library:
-                    LibraryView(selectedTab: $selectedTab, userProfile: userProfile)
+                    LibraryView(selectedTab: $selectedTab, userProfile: $userProfile)
                 }
             }
         }

--- a/frontend/OnVoice/Model/UserProfile.swift
+++ b/frontend/OnVoice/Model/UserProfile.swift
@@ -1,0 +1,22 @@
+//
+//  UserProfile.swift
+//  OnVoice
+//
+
+import Foundation
+
+struct UserProfile: Equatable {
+    var nickname: String
+    var defaultImageName: String
+    var customImageData: Data?
+
+    static let placeholder = UserProfile(
+        nickname: "",
+        defaultImageName: "",
+        customImageData: nil
+    )
+
+    var displayNickname: String {
+        nickname.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/frontend/OnVoice/Model/UserProfile.swift
+++ b/frontend/OnVoice/Model/UserProfile.swift
@@ -19,4 +19,22 @@ struct UserProfile: Equatable {
     var displayNickname: String {
         nickname.trimmingCharacters(in: .whitespacesAndNewlines)
     }
+
+    var displayImageName: String? {
+        guard customImageData == nil else { return nil }
+        return defaultImageName.isEmpty ? nil : defaultImageName
+    }
+
+    var displayImageData: Data? {
+        customImageData
+    }
+
+    mutating func applyDefaultImageName(_ imageName: String) {
+        defaultImageName = imageName
+        customImageData = nil
+    }
+
+    mutating func applyCustomImageData(_ imageData: Data) {
+        customImageData = imageData
+    }
 }

--- a/frontend/OnVoice/View/Components/HomeHeaderView.swift
+++ b/frontend/OnVoice/View/Components/HomeHeaderView.swift
@@ -7,8 +7,7 @@ import SwiftUI
 
 struct HomeHeaderView: View {
     let title: String
-    var profileImageName: String? = nil
-    var profileImageData: Data? = nil
+    var userProfile: UserProfile? = nil
     var showsProfileButton: Bool = true
     var titleTopOffset: CGFloat = 0
     var onProfileButtonTap: (() -> Void)? = nil
@@ -97,14 +96,14 @@ struct HomeHeaderView: View {
 
     @ViewBuilder
     private var profileButtonContent: some View {
-        if let profileImageData,
+        if let profileImageData = userProfile?.displayImageData,
            let uiImage = UIImage(data: profileImageData) {
             Image(uiImage: uiImage)
                 .resizable()
                 .scaledToFill()
                 .frame(width: 48, height: 48)
                 .clipShape(Circle())
-        } else if let profileImageName, !profileImageName.isEmpty {
+        } else if let profileImageName = userProfile?.displayImageName {
             Image(profileImageName)
                 .resizable()
                 .scaledToFill()

--- a/frontend/OnVoice/View/Components/HomeHeaderView.swift
+++ b/frontend/OnVoice/View/Components/HomeHeaderView.swift
@@ -7,6 +7,8 @@ import SwiftUI
 
 struct HomeHeaderView: View {
     let title: String
+    var profileImageName: String? = nil
+    var profileImageData: Data? = nil
     var showsProfileButton: Bool = true
     var titleTopOffset: CGFloat = 0
     var onProfileButtonTap: (() -> Void)? = nil
@@ -80,15 +82,7 @@ struct HomeHeaderView: View {
                     Button {
                         onProfileButtonTap?()
                     } label: {
-                        ZStack {
-                            Circle()
-                                .fill(Color.gray8.opacity(0.92))
-
-                            Image(systemName: "person.crop.circle.fill")
-                                .font(.system(size: 28))
-                                .foregroundColor(.gray2)
-                        }
-                        .frame(width: 48, height: 48)
+                        profileButtonContent
                     }
                     .buttonStyle(.plain)
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
@@ -99,6 +93,34 @@ struct HomeHeaderView: View {
             .frame(height: headerHeight)
         }
         .frame(height: headerHeight)
+    }
+
+    @ViewBuilder
+    private var profileButtonContent: some View {
+        if let profileImageData,
+           let uiImage = UIImage(data: profileImageData) {
+            Image(uiImage: uiImage)
+                .resizable()
+                .scaledToFill()
+                .frame(width: 48, height: 48)
+                .clipShape(Circle())
+        } else if let profileImageName, !profileImageName.isEmpty {
+            Image(profileImageName)
+                .resizable()
+                .scaledToFill()
+                .frame(width: 48, height: 48)
+                .clipShape(Circle())
+        } else {
+            ZStack {
+                Circle()
+                    .fill(Color.gray8.opacity(0.92))
+
+                Image(systemName: "person.crop.circle.fill")
+                    .font(.system(size: 28))
+                    .foregroundColor(.gray2)
+            }
+            .frame(width: 48, height: 48)
+        }
     }
 }
 

--- a/frontend/OnVoice/View/HomeView.swift
+++ b/frontend/OnVoice/View/HomeView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct HomeView: View {
     @EnvironmentObject var recorder: AudioRecorder
     @Binding var selectedTab: OnVoiceTab
-    let userProfile: UserProfile
+    @Binding var userProfile: UserProfile
     @State private var isShowingSituationRecognition = false
     @State private var isShowingMyPage = false
     @State private var selectedRecording: Recording?
@@ -109,7 +109,7 @@ struct HomeView: View {
                 SituationRecognitionView()
             }
             .navigationDestination(isPresented: $isShowingMyPage) {
-                MyPageView(userProfile: userProfile)
+                MyPageView(userProfile: $userProfile)
             }
             .navigationDestination(item: $selectedRecording) { recording in
                 AnalysisSummaryView(recording: recording)
@@ -269,6 +269,6 @@ struct HomeView: View {
 }
 
 #Preview {
-    HomeView(selectedTab: .constant(.home), userProfile: .placeholder)
+    HomeView(selectedTab: .constant(.home), userProfile: .constant(.placeholder))
         .environmentObject(AudioRecorder())
 }

--- a/frontend/OnVoice/View/HomeView.swift
+++ b/frontend/OnVoice/View/HomeView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct HomeView: View {
     @EnvironmentObject var recorder: AudioRecorder
     @Binding var selectedTab: OnVoiceTab
+    let userProfile: UserProfile
     @State private var isShowingSituationRecognition = false
     @State private var isShowingMyPage = false
     @State private var selectedRecording: Recording?
@@ -33,6 +34,8 @@ struct HomeView: View {
                 VStack(spacing: 0) {
                     HomeHeaderView(
                         title: todayDateString(),
+                        profileImageName: userProfile.defaultImageName,
+                        profileImageData: userProfile.customImageData,
                         showsProfileButton: true,
                         onProfileButtonTap: {
                             isShowingMyPage = true
@@ -106,7 +109,7 @@ struct HomeView: View {
                 SituationRecognitionView()
             }
             .navigationDestination(isPresented: $isShowingMyPage) {
-                MyPageView()
+                MyPageView(userProfile: userProfile)
             }
             .navigationDestination(item: $selectedRecording) { recording in
                 AnalysisSummaryView(recording: recording)
@@ -266,6 +269,6 @@ struct HomeView: View {
 }
 
 #Preview {
-    HomeView(selectedTab: .constant(.home))
+    HomeView(selectedTab: .constant(.home), userProfile: .placeholder)
         .environmentObject(AudioRecorder())
 }

--- a/frontend/OnVoice/View/HomeView.swift
+++ b/frontend/OnVoice/View/HomeView.swift
@@ -34,8 +34,7 @@ struct HomeView: View {
                 VStack(spacing: 0) {
                     HomeHeaderView(
                         title: todayDateString(),
-                        profileImageName: userProfile.defaultImageName,
-                        profileImageData: userProfile.customImageData,
+                        userProfile: userProfile,
                         showsProfileButton: true,
                         onProfileButtonTap: {
                             isShowingMyPage = true

--- a/frontend/OnVoice/View/LibraryView.swift
+++ b/frontend/OnVoice/View/LibraryView.swift
@@ -33,8 +33,7 @@ struct LibraryView: View {
                 VStack(spacing: 0) {
                     HomeHeaderView(
                         title: "라이브러리",
-                        profileImageName: userProfile.defaultImageName,
-                        profileImageData: userProfile.customImageData,
+                        userProfile: userProfile,
                         showsProfileButton: true,
                         titleTopOffset: 32,
                         onProfileButtonTap: {

--- a/frontend/OnVoice/View/LibraryView.swift
+++ b/frontend/OnVoice/View/LibraryView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 struct LibraryView: View {
     @EnvironmentObject var recorder: AudioRecorder
     @Binding var selectedTab: OnVoiceTab
+    let userProfile: UserProfile
     @State private var isShowingSituationRecognition = false
     @State private var isShowingLibraryOptionsAlert = false
     @State private var selectedRecording: Recording?
@@ -31,6 +32,8 @@ struct LibraryView: View {
                 VStack(spacing: 0) {
                     HomeHeaderView(
                         title: "라이브러리",
+                        profileImageName: userProfile.defaultImageName,
+                        profileImageData: userProfile.customImageData,
                         showsProfileButton: true,
                         titleTopOffset: 32,
                         onTitleTrailingButtonTap: {
@@ -294,6 +297,6 @@ struct LibraryView: View {
 }
 
 #Preview {
-    LibraryView(selectedTab: .constant(.library))
+    LibraryView(selectedTab: .constant(.library), userProfile: .placeholder)
         .environmentObject(AudioRecorder())
 }

--- a/frontend/OnVoice/View/LibraryView.swift
+++ b/frontend/OnVoice/View/LibraryView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 struct LibraryView: View {
     @EnvironmentObject var recorder: AudioRecorder
     @Binding var selectedTab: OnVoiceTab
-    let userProfile: UserProfile
+    @Binding var userProfile: UserProfile
     @State private var isShowingSituationRecognition = false
     @State private var isShowingMyPage = false
     @State private var isShowingLibraryOptionsAlert = false
@@ -65,7 +65,7 @@ struct LibraryView: View {
                 SituationRecognitionView()
             }
             .navigationDestination(isPresented: $isShowingMyPage) {
-                MyPageView(userProfile: userProfile)
+                MyPageView(userProfile: $userProfile)
             }
             .navigationDestination(item: $selectedRecording) { recording in
                 AnalysisSummaryView(recording: recording)
@@ -304,6 +304,6 @@ struct LibraryView: View {
 }
 
 #Preview {
-    LibraryView(selectedTab: .constant(.library), userProfile: .placeholder)
+    LibraryView(selectedTab: .constant(.library), userProfile: .constant(.placeholder))
         .environmentObject(AudioRecorder())
 }

--- a/frontend/OnVoice/View/LibraryView.swift
+++ b/frontend/OnVoice/View/LibraryView.swift
@@ -10,6 +10,7 @@ struct LibraryView: View {
     @Binding var selectedTab: OnVoiceTab
     let userProfile: UserProfile
     @State private var isShowingSituationRecognition = false
+    @State private var isShowingMyPage = false
     @State private var isShowingLibraryOptionsAlert = false
     @State private var selectedRecording: Recording?
     @State private var openedRowID: Recording.ID?
@@ -36,6 +37,9 @@ struct LibraryView: View {
                         profileImageData: userProfile.customImageData,
                         showsProfileButton: true,
                         titleTopOffset: 32,
+                        onProfileButtonTap: {
+                            isShowingMyPage = true
+                        },
                         onTitleTrailingButtonTap: {
                             isShowingLibraryOptionsAlert = true
                         }
@@ -59,6 +63,9 @@ struct LibraryView: View {
             .toolbar(.hidden, for: .navigationBar)
             .navigationDestination(isPresented: $isShowingSituationRecognition) {
                 SituationRecognitionView()
+            }
+            .navigationDestination(isPresented: $isShowingMyPage) {
+                MyPageView(userProfile: userProfile)
             }
             .navigationDestination(item: $selectedRecording) { recording in
                 AnalysisSummaryView(recording: recording)

--- a/frontend/OnVoice/View/MyPageView.swift
+++ b/frontend/OnVoice/View/MyPageView.swift
@@ -7,9 +7,8 @@ import SwiftUI
 
 struct MyPageView: View {
     @Environment(\.dismiss) private var dismiss
+    let userProfile: UserProfile
 
-    private let defaultProfileImageName = "profileDefaultYellow"
-    private let nickname = "도연바보뽕뽕삼"
     private let baseScreenWidth: CGFloat = 393
     private let baseContentHeight: CGFloat = 772
     private var appVersion: String {
@@ -75,9 +74,7 @@ struct MyPageView: View {
     private func profileSection(widthScale: CGFloat) -> some View {
         VStack(spacing: 18) {
             ZStack(alignment: .bottomTrailing) {
-                Image(defaultProfileImageName)
-                    .resizable()
-                    .scaledToFill()
+                profileImageView
                     .frame(width: 104, height: 104)
                     .clipShape(Circle())
 
@@ -93,14 +90,33 @@ struct MyPageView: View {
                 .offset(x: -1, y: -1)
             }
 
-            Text(nickname)
-                .font(.Pretendard.Bold.size18)
-                .foregroundStyle(Color.white)
-                .lineLimit(1)
-                .minimumScaleFactor(0.9)
+            if !userProfile.displayNickname.isEmpty {
+                Text(userProfile.displayNickname)
+                    .font(.Pretendard.Bold.size18)
+                    .foregroundStyle(Color.white)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.9)
+            }
         }
         .frame(maxWidth: .infinity)
         .padding(.horizontal, 144.5 * widthScale)
+    }
+
+    @ViewBuilder
+    private var profileImageView: some View {
+        if let customImageData = userProfile.customImageData,
+           let uiImage = UIImage(data: customImageData) {
+            Image(uiImage: uiImage)
+                .resizable()
+                .scaledToFill()
+        } else if !userProfile.defaultImageName.isEmpty {
+            Image(userProfile.defaultImageName)
+                .resizable()
+                .scaledToFill()
+        } else {
+            Circle()
+                .fill(Color.gray2)
+        }
     }
 
     private func socialAccountRow(widthScale: CGFloat, heightScale: CGFloat) -> some View {
@@ -232,6 +248,6 @@ private struct MyPageMenuRow: View {
 
 #Preview {
     NavigationStack {
-        MyPageView()
+        MyPageView(userProfile: .placeholder)
     }
 }

--- a/frontend/OnVoice/View/MyPageView.swift
+++ b/frontend/OnVoice/View/MyPageView.swift
@@ -4,10 +4,16 @@
 //
 
 import SwiftUI
+import PhotosUI
+import Photos
 
 struct MyPageView: View {
     @Environment(\.dismiss) private var dismiss
-    let userProfile: UserProfile
+    @Binding var userProfile: UserProfile
+    @State private var showsImageSheet = false
+    @State private var showsPhotoPicker = false
+    @State private var selectedPhotoItem: PhotosPickerItem?
+    @State private var showsPhotoPermissionAlert = false
 
     private let baseScreenWidth: CGFloat = 393
     private let baseContentHeight: CGFloat = 772
@@ -48,9 +54,36 @@ struct MyPageView: View {
                 withdrawalButton()
                     .padding(.bottom, proxy.safeAreaInsets.bottom * heightScale)
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+
+                if showsImageSheet {
+                    imageSelectionSheet
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
             }
         }
         .toolbar(.hidden, for: .navigationBar)
+        .animation(.easeInOut(duration: 0.2), value: showsImageSheet)
+        .photosPicker(isPresented: $showsPhotoPicker, selection: $selectedPhotoItem, matching: .images)
+        .alert("사진 권한이 필요해요", isPresented: $showsPhotoPermissionAlert) {
+            Button("취소", role: .cancel) {}
+            Button("설정 열기") {
+                guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+                UIApplication.shared.open(url)
+            }
+        } message: {
+            Text("갤러리에서 프로필 이미지를 선택하려면 사진 접근 권한을 허용해주세요.")
+        }
+        .onChange(of: selectedPhotoItem) { newValue in
+            guard let newValue else { return }
+
+            Task {
+                if let data = try? await newValue.loadTransferable(type: Data.self) {
+                    await MainActor.run {
+                        userProfile.customImageData = data
+                    }
+                }
+            }
+        }
     }
 
     private var headerView: some View {
@@ -78,15 +111,20 @@ struct MyPageView: View {
                     .frame(width: 104, height: 104)
                     .clipShape(Circle())
 
-                ZStack {
-                    Circle()
-                        .fill(Color.gray1)
+                Button {
+                    showsImageSheet = true
+                } label: {
+                    ZStack {
+                        Circle()
+                            .fill(Color.gray1)
 
-                    Image(systemName: "camera.fill")
-                        .font(.system(size: 14, weight: .semibold))
-                        .foregroundStyle(Color.gray6)
+                        Image(systemName: "camera.fill")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundStyle(Color.gray6)
+                    }
+                    .frame(width: 32, height: 32)
                 }
-                .frame(width: 32, height: 32)
+                .buttonStyle(.plain)
                 .offset(x: -1, y: -1)
             }
 
@@ -217,6 +255,111 @@ struct MyPageView: View {
         .frame(maxWidth: .infinity)
     }
 
+    private var imageSelectionSheet: some View {
+        ZStack(alignment: .bottom) {
+            Color(hex: "15161C").opacity(0.8)
+                .ignoresSafeArea()
+                .onTapGesture {
+                    showsImageSheet = false
+                }
+
+            VStack(spacing: 0) {
+                Text("이미지 선택하기")
+                    .font(.Pretendard.SemiBold.size18)
+                    .foregroundStyle(Color.white)
+                    .padding(.top, 22)
+                    .padding(.bottom, 26)
+
+                Button {
+                    userProfile.defaultImageName = MyPageProfileDefaultImage.randomName(
+                        excluding: userProfile.defaultImageName.isEmpty ? nil : userProfile.defaultImageName
+                    )
+                    userProfile.customImageData = nil
+                    showsImageSheet = false
+                } label: {
+                    sheetRow(systemImage: "photo", title: "기본 이미지로 설정하기")
+                }
+                .buttonStyle(.plain)
+
+                Button {
+                    Task {
+                        await handleGallerySelection()
+                    }
+                } label: {
+                    sheetRow(systemImage: "photo.on.rectangle.angled", title: "갤러리에서 선택하기")
+                }
+                .buttonStyle(.plain)
+
+                Capsule()
+                    .fill(Color.sub)
+                    .frame(width: 134, height: 5)
+                    .padding(.top, 26)
+                    .padding(.bottom, 10)
+            }
+            .frame(maxWidth: .infinity)
+            .background(Color.gray10)
+            .clipShape(
+                RoundedRectangle(cornerRadius: 24, style: .continuous)
+            )
+        }
+    }
+
+    private func sheetRow(systemImage: String, title: String) -> some View {
+        HStack(spacing: 14) {
+            Image(systemName: systemImage)
+                .font(.system(size: 18, weight: .medium))
+                .foregroundStyle(Color.white)
+                .frame(width: 18)
+
+            Text(title)
+                .font(.Pretendard.Medium.size18)
+                .foregroundStyle(Color.white)
+
+            Spacer()
+        }
+        .padding(.horizontal, 22)
+        .frame(height: 54)
+    }
+
+    @MainActor
+    private func handleGallerySelection() async {
+        showsImageSheet = false
+
+        let currentStatus = PHPhotoLibrary.authorizationStatus(for: .readWrite)
+        let status: PHAuthorizationStatus
+
+        switch currentStatus {
+        case .notDetermined:
+            status = await PHPhotoLibrary.requestAuthorization(for: .readWrite)
+        default:
+            status = currentStatus
+        }
+
+        switch status {
+        case .authorized, .limited:
+            showsPhotoPicker = true
+        case .denied, .restricted:
+            showsPhotoPermissionAlert = true
+        case .notDetermined:
+            break
+        @unknown default:
+            break
+        }
+    }
+
+}
+
+private enum MyPageProfileDefaultImage {
+    static let names = [
+        "profileDefaultYellow",
+        "profileDefaultPurple",
+        "profileDefaultPink"
+    ]
+
+    static func randomName(excluding currentName: String? = nil) -> String {
+        let availableNames = names.filter { $0 != currentName }
+        return availableNames.randomElement() ?? currentName ?? names[0]
+    }
 }
 
 private struct MyPageMenuRow: View {
@@ -248,6 +391,6 @@ private struct MyPageMenuRow: View {
 
 #Preview {
     NavigationStack {
-        MyPageView(userProfile: .placeholder)
+        MyPageView(userProfile: .constant(.placeholder))
     }
 }

--- a/frontend/OnVoice/View/MyPageView.swift
+++ b/frontend/OnVoice/View/MyPageView.swift
@@ -5,7 +5,6 @@
 
 import SwiftUI
 import PhotosUI
-import Photos
 
 struct MyPageView: View {
     @Environment(\.dismiss) private var dismiss
@@ -13,7 +12,6 @@ struct MyPageView: View {
     @State private var showsImageSheet = false
     @State private var showsPhotoPicker = false
     @State private var selectedPhotoItem: PhotosPickerItem?
-    @State private var showsPhotoPermissionAlert = false
 
     private let baseScreenWidth: CGFloat = 393
     private let baseContentHeight: CGFloat = 772
@@ -64,22 +62,18 @@ struct MyPageView: View {
         .toolbar(.hidden, for: .navigationBar)
         .animation(.easeInOut(duration: 0.2), value: showsImageSheet)
         .photosPicker(isPresented: $showsPhotoPicker, selection: $selectedPhotoItem, matching: .images)
-        .alert("사진 권한이 필요해요", isPresented: $showsPhotoPermissionAlert) {
-            Button("취소", role: .cancel) {}
-            Button("설정 열기") {
-                guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
-                UIApplication.shared.open(url)
-            }
-        } message: {
-            Text("갤러리에서 프로필 이미지를 선택하려면 사진 접근 권한을 허용해주세요.")
-        }
         .onChange(of: selectedPhotoItem) { newValue in
             guard let newValue else { return }
 
             Task {
                 if let data = try? await newValue.loadTransferable(type: Data.self) {
                     await MainActor.run {
-                        userProfile.customImageData = data
+                        userProfile.applyCustomImageData(data)
+                        selectedPhotoItem = nil
+                    }
+                } else {
+                    await MainActor.run {
+                        selectedPhotoItem = nil
                     }
                 }
             }
@@ -142,13 +136,13 @@ struct MyPageView: View {
 
     @ViewBuilder
     private var profileImageView: some View {
-        if let customImageData = userProfile.customImageData,
+        if let customImageData = userProfile.displayImageData,
            let uiImage = UIImage(data: customImageData) {
             Image(uiImage: uiImage)
                 .resizable()
                 .scaledToFill()
-        } else if !userProfile.defaultImageName.isEmpty {
-            Image(userProfile.defaultImageName)
+        } else if let defaultImageName = userProfile.displayImageName {
+            Image(defaultImageName)
                 .resizable()
                 .scaledToFill()
         } else {
@@ -271,10 +265,11 @@ struct MyPageView: View {
                     .padding(.bottom, 26)
 
                 Button {
-                    userProfile.defaultImageName = MyPageProfileDefaultImage.randomName(
+                    userProfile.applyDefaultImageName(
+                        MyPageProfileDefaultImage.randomName(
                         excluding: userProfile.defaultImageName.isEmpty ? nil : userProfile.defaultImageName
+                        )
                     )
-                    userProfile.customImageData = nil
                     showsImageSheet = false
                 } label: {
                     sheetRow(systemImage: "photo", title: "기본 이미지로 설정하기")
@@ -282,9 +277,8 @@ struct MyPageView: View {
                 .buttonStyle(.plain)
 
                 Button {
-                    Task {
-                        await handleGallerySelection()
-                    }
+                    showsImageSheet = false
+                    showsPhotoPicker = true
                 } label: {
                     sheetRow(systemImage: "photo.on.rectangle.angled", title: "갤러리에서 선택하기")
                 }
@@ -319,32 +313,6 @@ struct MyPageView: View {
         }
         .padding(.horizontal, 22)
         .frame(height: 54)
-    }
-
-    @MainActor
-    private func handleGallerySelection() async {
-        showsImageSheet = false
-
-        let currentStatus = PHPhotoLibrary.authorizationStatus(for: .readWrite)
-        let status: PHAuthorizationStatus
-
-        switch currentStatus {
-        case .notDetermined:
-            status = await PHPhotoLibrary.requestAuthorization(for: .readWrite)
-        default:
-            status = currentStatus
-        }
-
-        switch status {
-        case .authorized, .limited:
-            showsPhotoPicker = true
-        case .denied, .restricted:
-            showsPhotoPermissionAlert = true
-        case .notDetermined:
-            break
-        @unknown default:
-            break
-        }
     }
 
 }

--- a/frontend/OnVoice/View/ProfileSetupView.swift
+++ b/frontend/OnVoice/View/ProfileSetupView.swift
@@ -295,7 +295,7 @@ struct ProfileSetupView: View {
 
     private var imageSelectionSheet: some View {
         ZStack(alignment: .bottom) {
-            Color.black.opacity(0.32)
+            Color(hex: "15161C").opacity(0.8)
                 .ignoresSafeArea()
                 .onTapGesture {
                     showsImageSheet = false
@@ -303,8 +303,8 @@ struct ProfileSetupView: View {
 
             VStack(spacing: 0) {
                 Text("이미지 선택하기")
-                    .font(.Pretendard.SemiBold.size20)
-                    .foregroundStyle(Color.sub)
+                    .font(.Pretendard.SemiBold.size18)
+                    .foregroundStyle(Color.white)
                     .padding(.top, 22)
                     .padding(.bottom, 26)
 
@@ -345,12 +345,12 @@ struct ProfileSetupView: View {
         HStack(spacing: 14) {
             Image(systemName: systemImage)
                 .font(.system(size: 18, weight: .medium))
-                .foregroundStyle(Color.sub)
+                .foregroundStyle(Color.white)
                 .frame(width: 18)
 
             Text(title)
                 .font(.Pretendard.Medium.size18)
-                .foregroundStyle(Color.sub)
+                .foregroundStyle(Color.white)
 
             Spacer()
         }
@@ -360,7 +360,7 @@ struct ProfileSetupView: View {
 
     private var permissionSheet: some View {
         ZStack(alignment: .bottom) {
-            Color.black.opacity(0.58)
+            Color(hex: "15161C").opacity(0.8)
                 .ignoresSafeArea()
 
             VStack(alignment: .leading, spacing: 0) {

--- a/frontend/OnVoice/View/ProfileSetupView.swift
+++ b/frontend/OnVoice/View/ProfileSetupView.swift
@@ -11,7 +11,7 @@ import Speech
 import UserNotifications
 
 struct ProfileSetupView: View {
-    let onNext: () -> Void
+    let onNext: (UserProfile) -> Void
 
     @State private var defaultProfileImageName = ProfileDefaultImage.randomName()
     @FocusState private var isNicknameFocused: Bool
@@ -21,6 +21,7 @@ struct ProfileSetupView: View {
     @State private var showsPhotoPicker = false
     @State private var selectedPhotoItem: PhotosPickerItem?
     @State private var selectedProfileImage: Image?
+    @State private var selectedProfileImageData: Data?
     @State private var microphonePermission = PermissionState.unknown
     @State private var speechPermission = PermissionState.unknown
     @State private var notificationPermission = PermissionState.unknown
@@ -149,6 +150,7 @@ struct ProfileSetupView: View {
                 if let data = try? await newValue.loadTransferable(type: Data.self),
                    let uiImage = UIImage(data: data) {
                     await MainActor.run {
+                        selectedProfileImageData = data
                         selectedProfileImage = Image(uiImage: uiImage)
                     }
                 }
@@ -308,6 +310,7 @@ struct ProfileSetupView: View {
 
                 Button {
                     defaultProfileImageName = ProfileDefaultImage.randomName(excluding: defaultProfileImageName)
+                    selectedProfileImageData = nil
                     selectedProfileImage = nil
                     showsImageSheet = false
                 } label: {
@@ -426,7 +429,13 @@ struct ProfileSetupView: View {
 
                 Button {
                     showsPermissionSheet = false
-                    onNext()
+                    onNext(
+                        UserProfile(
+                            nickname: trimmedNickname,
+                            defaultImageName: defaultProfileImageName,
+                            customImageData: selectedProfileImageData
+                        )
+                    )
                 } label: {
                     Text("시작하기")
                         .font(.Pretendard.SemiBold.size20)
@@ -668,5 +677,5 @@ private enum PhotoLibraryPermissionRequester {
 }
 
 #Preview {
-    ProfileSetupView(onNext: {})
+    ProfileSetupView(onNext: { _ in })
 }

--- a/frontend/OnVoice/View/ProfileSetupView.swift
+++ b/frontend/OnVoice/View/ProfileSetupView.swift
@@ -152,6 +152,11 @@ struct ProfileSetupView: View {
                     await MainActor.run {
                         selectedProfileImageData = data
                         selectedProfileImage = Image(uiImage: uiImage)
+                        selectedPhotoItem = nil
+                    }
+                } else {
+                    await MainActor.run {
+                        selectedPhotoItem = nil
                     }
                 }
             }


### PR DESCRIPTION
## Summary
<!-- 이 PR의 목적과 주요 변경 사항을 간단히 설명하세요. -->
마이페이지에서 프로필 이미지를 수정할 수 있도록 바텀시트와 갤러리 선택 흐름을 연결하고,
온보딩에서 설정한 프로필 이미지/닉네임이 홈, 라이브러리, 마이페이지에 공통으로 반영되도록 연동했습니다.


## Related Issue
<!-- Projects에서 이 PR과 관련된 이슈를 링크하세요. -->
- issue: #65


## Changes (변경 사항)
<!-- 주요 변경 사항을 목록으로 작성하세요. (예: `컴포넌트 A의 스타일 수정`, `API 요청 로직 개선`) -->
- 마이페이지 프로필 카메라 버튼 탭 시 이미지 선택 바텀시트 노출 구현
- 마이페이지에서 기본 이미지 변경 기능 연결
- 마이페이지에서 갤러리 이미지 선택 기능 연결
- 온보딩에서 설정한 프로필 이미지/닉네임을 홈, 라이브러리, 마이페이지에 공통 반영하도록 상태 연동
- 홈/라이브러리 프로필 버튼에서 마이페이지 진입 시 동일한 프로필 이미지 표시
- UserProfile 모델에서 프로필 이미지 표시 우선순위를 공통 관리하도록 정리
- PhotosPicker 선택 후 상태 초기화 처리 추가
- 마이페이지 바텀시트 UI를 온보딩 프로필 이미지 선택 바텀시트와 동일한 스타일로 조정
- 바텀시트 딤 배경, 텍스트/아이콘 색상, 폰트 스타일 세부 조정

## Test
<!-- 어떻게 테스트했는지 설명해주세요 -->
- [x] 로컬에서 테스트 완료
- [x] 기존 기능에 영향 없음
### 실행한 테스트
- 온보딩에서 기본 프로필 이미지 선택 후 홈/라이브러리/마이페이지에 동일하게 반영되는지 확인
- 온보딩에서 갤러리 이미지 선택 후 홈/라이브러리/마이페이지에 동일하게 반영되는지 확인
- 마이페이지 카메라 버튼 탭 시 이미지 선택 바텀시트가 정상 노출되는지 확인
- 마이페이지에서 기본 이미지 변경 시 즉시 프로필 이미지가 갱신되는지 확인
- 마이페이지에서 갤러리 선택 시 이미지 반영이 정상 동작하는지 확인
- 홈/라이브러리에서 프로필 버튼 탭 시 마이페이지로 정상 이동하는지 확인

## Screenshots (Optional)
<!-- UI 등 변경에 대한 스크린샷을 첨부하세요. 아래 표 삭제 후 자유롭게 첨부해도 됩니다. -->
| 요구사항 | 변경 초기 | 변경 최종 | 온보딩화면에도 반영 | 
|:--:|:--:|:--:|:--:|
| <img width="393" height="852" alt="6-1 프로필 이미지 변경" src="https://github.com/user-attachments/assets/13686b49-272f-4947-a14d-bd800a540fea" /> | <img width="393" height="854" alt="simulator_screenshot_D9E1F8F3-D1F9-4D05-A4F2-3A75B8133876 1" src="https://github.com/user-attachments/assets/d7869b61-db9b-4122-affa-5e104cdf7d69" /> | <img width="393" height="854" alt="simulator_screenshot_48DBA142-8406-4E9F-94F7-D315A2CBB84F 1" src="https://github.com/user-attachments/assets/ef48f769-ad5e-4cd9-946a-47af156803bc" /> | <img width="393" height="854" alt="simulator_screenshot_E144BF53-DF21-444F-A0D5-E8B5ABC28494 1" src="https://github.com/user-attachments/assets/c0f58ab3-b515-4278-8df8-c294cdaa5f47" />

| 프로필변경 | 홈화면 | 라이브러리 |  
|:--:|:--:|:--:|
| <img width="393" height="854" alt="simulator_screenshot_4C51E8C7-B768-4A34-B842-B8CAE444A48E 1" src="https://github.com/user-attachments/assets/70f5d90d-8de7-4ca6-9e0b-424332a1a71b" /> | <img width="393" height="854" alt="simulator_screenshot_95E626E3-4454-4FDD-B49A-5CB6A13C877F 1" src="https://github.com/user-attachments/assets/ade113d0-d38c-4e8f-a13b-b563e4686d5f" /> | <img width="393" height="854" alt="simulator_screenshot_082BDC17-E3A5-4A47-8372-20A0BCE36207 1" src="https://github.com/user-attachments/assets/13c329d1-aaa0-4fc9-8443-21fe1e942555" /> |


## Checklist
- [x] 변경사항 400줄 이하
- [ ] 필요시 테스트 추가
- [ ] 필요시 문서 업데이트

## Additional Context (Optional)
- 마이페이지 프로필 이미지 수정은 기존 온보딩 프로필 이미지 선택 플로우를 재사용해 구현했습니다.
- 프로필 이미지와 닉네임은 UserProfile 모델을 통해 홈, 라이브러리, 마이페이지에서 공통으로 관리됩니다.
- 현재 PR은 프로필 이미지 수정 플로우와 프로필 상태 연동 구현에 집중했습니다.
- placeholder 상태 표현 개선, 기본 이미지 선택 UX 개선, 테스트 보강은 필요 시 후속 작업으로 분리해 반영할 예정입니다.



<!-- 
# 다음 체크리스트를 꼭 확인해주세요 (이 주석 블록은 지워도 됨)
   1. 제목은 다음과 같이 설정해주세요. 제목은 간결하게, 뒤에 마침표 금지.
      => "작업유형지정: 제목"
      1-1. 작업 유형은 다음과 같습니다.
            feat:      새로운 기능 추가
            design:    CSS 등 사용자 UI 디자인 변경
            fix:        버그 수정
            style:     코드 formatting, 세미콜론 누락 등 코드 자체의 변경이 없는 경우
            docs:      문서 수정
            refactor:  코드 리팩토링
            test:      테스트 코드, 리팩토링 테스트 코드 추가
            chore:     패키지 매니저 수정, 그 외 기타 수정
            comment:   주석 추가 및 변경
            rename:  	파일, 폴더의 이름 수정 또는 이동
            remove:  	파일 삭제
            !HOTFIX: 	급하게 치명적인 버그를 고쳐야 하는 경우
            other:     기타
   2. Reviewers에 리뷰어를 지정해주세요.
   3. Assignees에 작성자 본인(리뷰이)을 지정해주세요.
   4. labels 태그를 지정해주세요. (작업유형과 같은 역할)
   5. 마크다운 문법을 활용해서 아래 문서를 작성해보세요. 
      => 참고 블로그: https://inpa.tistory.com/entry/MarkDown-%F0%9F%93%9A-%EB%A7%88%ED%81%AC%EB%8B%A4%EC%9A%B4-%EB%AC%B8%EB%B2%95-%F0%9F%92%AF-%EC%A0%95%EB%A6%AC
-->